### PR TITLE
update ci runners, setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,17 +12,19 @@ jobs:
     name: build documentation
     runs-on: ubuntu-latest
     steps:
-      - name: setup libssl for Ubuntu 24.04 runner
-        run: |
-          apt-get update && apt-get install -y librust-openssl-sys-dev
+
       - uses: actions/checkout@v4
+
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      
       - name: install rust nightly
         run: |
           rustup toolchain install nightly
+
       - name: generate rust docs
         run: |
           RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --workspace --no-deps --manifest-path rust/Cargo.toml
+
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@v2 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
     name: build documentation
-    runs-on: bam-runners
+    runs-on: ubuntu-latest
     steps:
       - name: setup libssl for Ubuntu 24.04 runner
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,8 @@ env:
 jobs:
   test:
     name: cargo test
-    runs-on: bam-runners
+    runs-on: ubuntu-latest
     steps:
-      - name: setup libssl for Ubuntu 24.04 runner
-        run: |
-          apt-get update && apt-get install -y librust-openssl-sys-dev
 
       - uses: actions/checkout@v4
 
@@ -27,7 +24,7 @@ jobs:
           rustup component add rustfmt
           cargo fmt --all --manifest-path rust/Cargo.toml -- --check
           
-      - name: Test Assets
+      - name: Install test assets
         run: |
           ./setup.sh
 


### PR DESCRIPTION
some small changes to action workflows:
  - runner name to `ubuntu-latest`
  - drop patch required on internal NREL runners for Ubuntu 24
