### PR TITLE
Rjf/bambam shapefile overlay

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,6 +58,7 @@ routee-compass-macros = { version = "0.19.2" }
 routee-compass-powertrain = { version = "0.19.2" }
 routee-compass-py = { version = "0.19.2" }
 rstar = { version = "0.12.2" }
+sanitize-filename = "0.6.0"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_arrow = { version = "0.14.0", features = ["arrow-58"] }
 serde_bytes = { version = "0.11.19" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,11 +52,11 @@ rand = "0.10.0"
 rayon = "1.10.0"
 regex = { version = "1.11.1" }
 reqwest = { version = "0.12.12", features = ["blocking"] }
-routee-compass = { version = "0.19.0" }
-routee-compass-core = { version = "0.19.0" }
-routee-compass-macros = { version = "0.19.0" }
-routee-compass-powertrain = { version = "0.19.0" }
-routee-compass-py = { version = "0.19.0" }
+routee-compass = { version = "0.19.2" }
+routee-compass-core = { version = "0.19.2" }
+routee-compass-macros = { version = "0.19.2" }
+routee-compass-powertrain = { version = "0.19.2" }
+routee-compass-py = { version = "0.19.2" }
 rstar = { version = "0.12.2" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_arrow = { version = "0.14.0", features = ["arrow-58"] }

--- a/rust/bambam/Cargo.toml
+++ b/rust/bambam/Cargo.toml
@@ -26,7 +26,6 @@ clap = { workspace = true }
 config = { workspace = true }
 csv = { workspace = true }
 # rusqlite = { workspace = true}
-
 env_logger = { workspace = true }
 flate2 = { workspace = true }
 geo = { workspace = true }
@@ -34,7 +33,6 @@ geo-traits = { workspace = true }
 geo-types = { workspace = true }
 geozero = { workspace = true }
 gtfs-structures = { workspace = true }
-
 h3o = { workspace = true }
 hex = { workspace = true }
 inventory = { workspace = true }
@@ -43,15 +41,13 @@ jsonpath-rust = { workspace = true }
 kdam = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
-
 rayon = { workspace = true }
 regex = { workspace = true }
 routee-compass = { workspace = true }
 routee-compass-core = { workspace = true }
 routee-compass-powertrain = { workspace = true }
-
 rstar = { workspace = true }
-
+sanitize-filename = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shapefile = { workspace = true }
@@ -59,6 +55,5 @@ skiplist = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
-
 uom = { workspace = true }
 zip = { workspace = true }

--- a/rust/bambam/src/app/mod.rs
+++ b/rust/bambam/src/app/mod.rs
@@ -1,2 +1,3 @@
 pub mod gtfs_config;
 pub mod oppvec;
+pub mod overlay;

--- a/rust/bambam/src/app/oppvec/app.rs
+++ b/rust/bambam/src/app/oppvec/app.rs
@@ -370,7 +370,7 @@ fn sample_point_from_triangle(t: &geo::Triangle<f32>, rng: &mut ThreadRng) -> ge
         r1 = 1.0 - r1;
         r2 = 1.0 - r2;
     }
-    let (p1, p2, p3) = (t.0, t.1, t.2);
+    let (p1, p2, p3) = (t.v1(), t.v2(), t.v3());
     // apply vectors to p1 that stretch it randomly towards p2 + p3
     let t1 = geo::Point(p1);
     let t2 = geo::Point(p2 - p1) * r1;

--- a/rust/bambam/src/app/overlay/app.rs
+++ b/rust/bambam/src/app/overlay/app.rs
@@ -23,12 +23,16 @@ pub fn run(
     overlay_source: &OverlaySource,
     col_type: &GeometryColumnType,
     _: &OverlayOperation,
+    verbose: bool,
 ) -> Result<(), String> {
     // fail early if IO error from read/write destinations
     let output_directory = Path::new(output_directory);
-    let output_dir = output_directory
-        .parent()
-        .expect("output file should have a parent directory");
+    std::fs::create_dir_all(output_directory).map_err(|e| {
+        format!(
+            "failure creating output directory '{}': {e}",
+            output_directory.as_os_str().to_string_lossy()
+        )
+    })?;
 
     // read overlay dataset
     let overlay_data = overlay_source.build()?;
@@ -48,17 +52,8 @@ pub fn run(
 
     let headers = build_header_lookup(&mut reader)?;
 
-    // let rows: Box<[MepRow]> = read_utils::from_csv(
-    //     &mep_filepath,
-    //     true,
-    //     Some(BarBuilder::default().desc("reading MEP rows")),
-    //     None,
-    // )
-    // .expect("failed to read mep file");
-    // log::info!("processed {} rows", rows.len());
-
     let grouped_rows: Vec<(String, (StringRecord, Geometry))> =
-        spatial_lookup(reader, overlay.clone(), &headers, col_type)?;
+        spatial_lookup(reader, overlay.clone(), &headers, col_type, verbose)?;
 
     let mut grouped_lookup: HashMap<String, (Geometry, Vec<StringRecord>)> = HashMap::new();
     for (grouping, (row, geom)) in grouped_rows.into_iter() {
@@ -85,7 +80,8 @@ pub fn run(
         total = len
     );
     for (id, (overlay, raw_rows)) in write_iter {
-        let out_filename = format!("{id}.csv");
+        let id_sani = sanitize_filename::sanitize(&id);
+        let out_filename = format!("{id_sani}.csv");
         let out_filepath = output_directory.join(out_filename);
         let mut output_writer = csv::Writer::from_path(&out_filepath).map_err(|e| {
             format!(
@@ -112,14 +108,8 @@ fn spatial_lookup(
     overlay: Arc<PolygonalRTree<f64, String>>,
     headers: &HashMap<String, usize>,
     col_type: &GeometryColumnType,
+    verbose: bool,
 ) -> Result<Vec<(String, (csv::StringRecord, Geometry))>, String> {
-    // let bar = Arc::new(Mutex::new(
-    //     BarBuilder::default()
-    //         .desc("spatial lookup")
-    //         // .total(rows.len())
-    //         .build()?,
-    // ));
-
     let iter = tqdm!(reader.into_records(), desc = "spatial lookup");
 
     let mut result = vec![];
@@ -133,16 +123,17 @@ fn spatial_lookup(
             .map_err(|e| format!("failure running spatial intersection for row {idx}: {e}"))?
             .collect_vec();
         match found[..] {
-            // [] => vec![],
             [single] => result.push((single.data.clone(), (row, point))),
-            _ => {} // _ => {
-                    //     let found_geoids = found.iter().map(|r| r.data.to_string()).join(", ");
-                    //     vec![Err(format!(
-                    //         "during spatial lookup, point {} unexpectedly found multiple matching geometries with ids: [{}]",
-                    //         point.to_wkt(),
-                    //         found_geoids
-                    //     ))]
-                    // }
+            [] if verbose => {
+                log::warn!("no spatial match found for row {idx}")
+            }
+            _ if verbose => {
+                log::warn!(
+                    "more than one spatial match ({} > 1) found for row {idx}",
+                    found.len()
+                )
+            }
+            _ => {}
         }
     }
 

--- a/rust/bambam/src/app/overlay/app.rs
+++ b/rust/bambam/src/app/overlay/app.rs
@@ -50,7 +50,7 @@ pub fn run(
         .trim(csv::Trim::Fields)
         .from_reader(file);
 
-    let headers = build_header_lookup(&mut reader)?;
+    let (header_record, headers) = build_header_lookup(&mut reader)?;
 
     let grouped_rows: Vec<(String, (StringRecord, Geometry))> =
         spatial_lookup(reader, overlay.clone(), &headers, col_type, verbose)?;
@@ -89,6 +89,10 @@ pub fn run(
                 out_filepath.as_os_str().to_string_lossy()
             )
         })?;
+
+        output_writer
+            .write_record(&header_record)
+            .map_err(|e| format!("failure writing header to output: {e}"))?;
 
         for row in raw_rows.into_iter() {
             output_writer
@@ -141,16 +145,19 @@ fn spatial_lookup(
     Ok(result)
 }
 
-pub fn build_header_lookup(reader: &mut Reader<File>) -> Result<HashMap<String, usize>, String> {
+pub fn build_header_lookup(
+    reader: &mut Reader<File>,
+) -> Result<(StringRecord, HashMap<String, usize>), String> {
     // We nest this call in its own scope because of lifetimes.
     let headers = reader
         .headers()
-        .map_err(|e| format!("failure retrieving headers: {e}"))?;
+        .map_err(|e| format!("failure retrieving headers: {e}"))?
+        .clone();
     let lookup: HashMap<String, usize> = headers
         .iter()
         .enumerate()
         .map(|(idx, col)| (String::from(col), idx))
         .collect::<HashMap<_, _>>();
 
-    Ok(lookup)
+    Ok((headers, lookup))
 }

--- a/rust/bambam/src/app/overlay/app.rs
+++ b/rust/bambam/src/app/overlay/app.rs
@@ -1,0 +1,165 @@
+use super::OverlayOperation;
+use crate::app::overlay::{GeometryColumnType, Grouping, OverlaySource};
+use csv::{Reader, StringRecord};
+use geo::Geometry;
+use itertools::Itertools;
+use kdam::{tqdm, BarBuilder, BarExt};
+use rayon::prelude::*;
+use routee_compass_core::util::{fs::read_utils, geo::PolygonalRTree};
+use std::{
+    collections::HashMap,
+    fs::File,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+/// function to aggregate mep output rows to some overlay geometry dataset.
+/// the number of output rows is not dependent on the size of the source geometry dataset,
+/// instead based on the number of geometry rows with matches in the mep dataset.
+/// only mep score and population data are aggregated at this time, via summation.
+pub fn run(
+    bambam_filepath: &str,
+    output_directory: &str,
+    overlay_source: &OverlaySource,
+    col_type: &GeometryColumnType,
+    _: &OverlayOperation,
+) -> Result<(), String> {
+    // fail early if IO error from read/write destinations
+    let output_directory = Path::new(output_directory);
+    let output_dir = output_directory
+        .parent()
+        .expect("output file should have a parent directory");
+
+    // read overlay dataset
+    let overlay_data = overlay_source.build()?;
+    log::info!("found {} rows in overlay dataset", overlay_data.len());
+    let overlay_lookup = overlay_data
+        .iter()
+        .map(|(geom, geoid)| (geoid.clone(), geom.clone()))
+        .collect::<HashMap<_, _>>();
+    let overlay: Arc<PolygonalRTree<f64, String>> = Arc::new(PolygonalRTree::new(overlay_data)?);
+
+    let mut file = std::fs::File::open(bambam_filepath)
+        .map_err(|e| format!("failure reading {bambam_filepath}: {e}"))?;
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::Fields)
+        .from_reader(file);
+
+    let headers = build_header_lookup(&mut reader)?;
+
+    // let rows: Box<[MepRow]> = read_utils::from_csv(
+    //     &mep_filepath,
+    //     true,
+    //     Some(BarBuilder::default().desc("reading MEP rows")),
+    //     None,
+    // )
+    // .expect("failed to read mep file");
+    // log::info!("processed {} rows", rows.len());
+
+    let grouped_rows: Vec<(String, (StringRecord, Geometry))> =
+        spatial_lookup(reader, overlay.clone(), &headers, col_type)?;
+
+    let mut grouped_lookup: HashMap<String, (Geometry, Vec<StringRecord>)> = HashMap::new();
+    for (grouping, (row, geom)) in grouped_rows.into_iter() {
+        match grouped_lookup.get_mut(&grouping) {
+            Some((_, v)) => v.push(row),
+            None => {
+                let geometry = overlay_lookup.get(&grouping).ok_or_else(|| {
+                    format!(
+                        "internal error, lookup missing geometry entry for id '{}'",
+                        grouping
+                    )
+                })?;
+                let _ = grouped_lookup.insert(grouping.clone(), (geometry.clone(), vec![row]));
+            }
+        }
+    }
+
+    let len = grouped_lookup.len();
+    let write_iter = tqdm!(
+        grouped_lookup
+            .into_iter()
+            .sorted_by_cached_key(|(k, _)| k.clone()),
+        desc = "writing partitioned datasets",
+        total = len
+    );
+    for (id, (overlay, raw_rows)) in write_iter {
+        let out_filename = format!("{id}.csv");
+        let out_filepath = output_directory.join(out_filename);
+        let mut output_writer = csv::Writer::from_path(&out_filepath).map_err(|e| {
+            format!(
+                "failure opening output file '{}': {e}",
+                out_filepath.as_os_str().to_string_lossy()
+            )
+        })?;
+
+        for row in raw_rows.into_iter() {
+            output_writer
+                .write_record(&row)
+                .map_err(|e| format!("failure writing row to output: {e}"))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// performs batch geospatial intersection operations to assign each [`MepRow`] its
+/// grouping identifier (GEOID). run in parallel over the rows argument, a chunk of
+/// the source MEP dataset.
+fn spatial_lookup(
+    reader: csv::Reader<File>,
+    overlay: Arc<PolygonalRTree<f64, String>>,
+    headers: &HashMap<String, usize>,
+    col_type: &GeometryColumnType,
+) -> Result<Vec<(String, (csv::StringRecord, Geometry))>, String> {
+    // let bar = Arc::new(Mutex::new(
+    //     BarBuilder::default()
+    //         .desc("spatial lookup")
+    //         // .total(rows.len())
+    //         .build()?,
+    // ));
+
+    let iter = tqdm!(reader.into_records(), desc = "spatial lookup");
+
+    let mut result = vec![];
+    for (idx, row_result) in iter.enumerate() {
+        let row = row_result.map_err(|e| format!("cannot read row {idx}: {e}"))?;
+        let point = col_type
+            .get_point(&row, headers)
+            .map_err(|e| format!("failure reading geometry from row {idx}: {e}"))?;
+        let found = overlay
+            .intersection(&point)
+            .map_err(|e| format!("failure running spatial intersection for row {idx}: {e}"))?
+            .collect_vec();
+        match found[..] {
+            // [] => vec![],
+            [single] => result.push((single.data.clone(), (row, point))),
+            _ => {} // _ => {
+                    //     let found_geoids = found.iter().map(|r| r.data.to_string()).join(", ");
+                    //     vec![Err(format!(
+                    //         "during spatial lookup, point {} unexpectedly found multiple matching geometries with ids: [{}]",
+                    //         point.to_wkt(),
+                    //         found_geoids
+                    //     ))]
+                    // }
+        }
+    }
+
+    eprintln!();
+    Ok(result)
+}
+
+pub fn build_header_lookup(reader: &mut Reader<File>) -> Result<HashMap<String, usize>, String> {
+    // We nest this call in its own scope because of lifetimes.
+    let headers = reader
+        .headers()
+        .map_err(|e| format!("failure retrieving headers: {e}"))?;
+    let lookup: HashMap<String, usize> = headers
+        .iter()
+        .enumerate()
+        .map(|(idx, col)| (String::from(col), idx))
+        .collect::<HashMap<_, _>>();
+
+    Ok(lookup)
+}

--- a/rust/bambam/src/app/overlay/geometry_column_type.rs
+++ b/rust/bambam/src/app/overlay/geometry_column_type.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use geo::{Coord, Geometry, Point};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum GeometryColumnType {
+    Geometry { col: String, format: GeometryFormat },
+    Xy { x: String, y: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum GeometryFormat {
+    Wkt,
+    Wkb,
+}
+
+impl GeometryColumnType {
+    pub fn new(
+        x: Option<&String>,
+        y: Option<&String>,
+        geom: Option<&String>,
+        format: Option<&GeometryFormat>,
+    ) -> Result<Self, String> {
+        match (x, y, geom, format) {
+            (Some(x_col), Some(y_col), None, None) => Ok(Self::Xy {
+                x: x_col.clone(),
+                y: y_col.clone(),
+            }),
+            (None, None, Some(geom_col), Some(f)) => Ok(Self::Geometry { col: geom_col.clone(), format: f.clone() }),
+            _ => Err(format!(
+                "must either provide x and y, or geometry column name and format, found {x:?} {y:?} {geom:?} {format:?}"
+            )),
+        }
+    }
+
+    pub fn get_point(
+        &self,
+        row: &csv::StringRecord,
+        lookup: &HashMap<String, usize>,
+    ) -> Result<Geometry, String> {
+        match self {
+            GeometryColumnType::Geometry { col, format } => {
+                todo!("deserialize a geometry directly from the row")
+            }
+            GeometryColumnType::Xy { x, y } => {
+                let x_idx = lookup
+                    .get(x)
+                    .ok_or_else(|| format!("header missing {x} column"))?;
+                let y_idx = lookup
+                    .get(y)
+                    .ok_or_else(|| format!("header missing {y} column"))?;
+                let x_str = row
+                    .get(*x_idx)
+                    .ok_or_else(|| format!("row missing {x} column at index {x_idx}"))?;
+                let y_str = row
+                    .get(*y_idx)
+                    .ok_or_else(|| format!("row missing {y} column at index {y_idx}"))?;
+                let x_val = x_str
+                    .parse()
+                    .map_err(|e| format!("row has invalid {x} value of {x_str}: {e}"))?;
+                let y_val = y_str
+                    .parse()
+                    .map_err(|e| format!("row has invalid {y} value of {y_str}: {e}"))?;
+                let point = Point::<f64>(Coord { x: x_val, y: y_val });
+                Ok(geo::Geometry::Point(point))
+            }
+        }
+    }
+}

--- a/rust/bambam/src/app/overlay/geometry_column_type.rs
+++ b/rust/bambam/src/app/overlay/geometry_column_type.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use clap::ValueEnum;
 use geo::{Coord, Geometry, Point};
 use geozero::{wkb::Wkb, wkt::Wkt, ToGeo};
 use serde::{Deserialize, Serialize};
@@ -11,7 +12,7 @@ pub enum GeometryColumnType {
     Xy { x: String, y: String },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum GeometryFormat {
     Wkt,

--- a/rust/bambam/src/app/overlay/geometry_column_type.rs
+++ b/rust/bambam/src/app/overlay/geometry_column_type.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use geo::{Coord, Geometry, Point};
+use geozero::{wkb::Wkb, wkt::Wkt, ToGeo};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -43,7 +44,20 @@ impl GeometryColumnType {
     ) -> Result<Geometry, String> {
         match self {
             GeometryColumnType::Geometry { col, format } => {
-                todo!("deserialize a geometry directly from the row")
+                let geom_idx = lookup
+                    .get(col)
+                    .ok_or_else(|| format!("header missing {col} column"))?;
+                let geom_str = row
+                    .get(*geom_idx)
+                    .ok_or_else(|| format!("row missing {col} column at index {geom_idx}"))?;
+                match format {
+                    GeometryFormat::Wkt => Wkt(geom_str).to_geo().map_err(|e| {
+                        format!("value at column {col} not a valid WKT geometry: {e}")
+                    }),
+                    GeometryFormat::Wkb => Wkb(geom_str).to_geo().map_err(|e| {
+                        format!("value at column {col} not a valid WKB geometry: {e}")
+                    }),
+                }
             }
             GeometryColumnType::Xy { x, y } => {
                 let x_idx = lookup

--- a/rust/bambam/src/app/overlay/grouping.rs
+++ b/rust/bambam/src/app/overlay/grouping.rs
@@ -1,0 +1,16 @@
+// use bamsoda_core::model::identifier::Geoid;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Grouping {
+    pub identifier: String,
+    pub mode: String,
+}
+
+impl Grouping {
+    pub fn new(geoid: String, mode: String) -> Grouping {
+        Grouping {
+            identifier: geoid,
+            mode,
+        }
+    }
+}

--- a/rust/bambam/src/app/overlay/mod.rs
+++ b/rust/bambam/src/app/overlay/mod.rs
@@ -1,0 +1,11 @@
+mod app;
+mod geometry_column_type;
+mod grouping;
+mod overlay_operation;
+mod overlay_source;
+
+pub use app::run;
+pub use geometry_column_type::{GeometryColumnType, GeometryFormat};
+pub use grouping::Grouping;
+pub use overlay_operation::OverlayOperation;
+pub use overlay_source::OverlaySource;

--- a/rust/bambam/src/app/overlay/overlay_operation.rs
+++ b/rust/bambam/src/app/overlay/overlay_operation.rs
@@ -1,0 +1,18 @@
+use std::fmt::Display;
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, ValueEnum, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlayOperation {
+    Intersection,
+}
+
+impl Display for OverlayOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OverlayOperation::Intersection => write!(f, "intersection"),
+        }
+    }
+}

--- a/rust/bambam/src/app/overlay/overlay_source.rs
+++ b/rust/bambam/src/app/overlay/overlay_source.rs
@@ -1,0 +1,169 @@
+// use bamsoda_core::model::identifier::Geoid;
+use flate2::read::GzDecoder;
+use geo::Geometry;
+use geozero::{wkt, ToGeo};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs::File, io::BufReader};
+
+/// source of overlay geometry dataset
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum OverlaySource {
+    /// reads overlay geometries from a CSV file that contains geometry and id columns
+    Csv {
+        file: String,
+        geometry_column: String,
+        id_column: String,
+    },
+    /// reads overlay geometries from a shapefile with an id field
+    Shapefile { file: String, id_field: String },
+    /// uses bamsoda-tiger to retrieve the geometries associated with the given geoids from the web
+    TigerLines { geoids: Vec<String> },
+}
+
+impl OverlaySource {
+    pub fn build(&self) -> Result<Vec<(Geometry, String)>, String> {
+        match self {
+            OverlaySource::Csv {
+                file,
+                geometry_column,
+                id_column,
+            } => read_overlay_csv(file, geometry_column, id_column),
+            OverlaySource::Shapefile { file, id_field } => read_overlay_shapefile(file, id_field),
+            OverlaySource::TigerLines { .. } => {
+                todo!("not yet implemented, requires improvements to bamcensus")
+            }
+        }
+    }
+}
+
+/// reads geometries and Strings from a shapefile source
+fn read_overlay_shapefile(
+    overlay_filepath: &str,
+    id_field: &str,
+) -> Result<Vec<(Geometry, String)>, String> {
+    let rows = shapefile::read(overlay_filepath)
+        .map_err(|e| format!("failed reading '{overlay_filepath}': {e}"))?;
+
+    let mut processed = vec![];
+    for (idx, (shape, record)) in rows.into_iter().enumerate() {
+        let geometry = match shape {
+            shapefile::Shape::Polygon(generic_polygon) => {
+                let mp: geo::MultiPolygon<f64> = generic_polygon.try_into().map_err(|e| {
+                    format!("failed to convert shapefile polygon at row {idx}: {e}")
+                })?;
+                geo::Geometry::MultiPolygon(mp)
+            }
+            shapefile::Shape::PolygonM(generic_polygon) => {
+                let mp: geo::MultiPolygon<f64> = generic_polygon.try_into().map_err(|e| {
+                    format!("failed to convert shapefile polygon at row {idx}: {e}")
+                })?;
+                geo::Geometry::MultiPolygon(mp)
+            }
+            _ => {
+                return Err(format!(
+                    "unexpected shape type {} found at row {}, must be polygonal",
+                    shape.shapetype(),
+                    idx
+                ))
+            }
+        };
+        let field = record
+            .get(id_field)
+            .ok_or_else(|| format!("field {id_field} missing from shapefile record"))?;
+        let geoid = match field {
+            shapefile::dbase::FieldValue::Character(Some(s)) => Ok(s.clone()),
+            shapefile::dbase::FieldValue::Numeric(Some(f)) => Ok(format!("{}", *f as i64)),
+            _ => Err(format!(
+                "field '{}' has unexpected field type '{}'",
+                id_field,
+                field.field_type()
+            )),
+        }?;
+        processed.push((geometry, geoid));
+    }
+    Ok(processed)
+}
+
+/// reads geometries and Strings from a CSV source
+fn read_overlay_csv(
+    overlay_filepath: &str,
+    geometry_column: &str,
+    id_column: &str,
+) -> Result<Vec<(Geometry, String)>, String> {
+    // read in overlay geometries file
+    // let overlay_path = Path::new(overlay_filepath);
+    let overlay_file = File::open(overlay_filepath)
+        .map_err(|e| format!("failure reading file {overlay_filepath}: {e}"))?;
+    let r: Box<dyn std::io::Read> = if overlay_filepath.ends_with(".gz") {
+        Box::new(BufReader::new(GzDecoder::new(overlay_file)))
+    } else {
+        Box::new(overlay_file)
+    };
+    let mut overlay_reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .trim(csv::Trim::Fields)
+        .from_reader(r);
+
+    // let mut overlay_reader = csv::Reader::from_path(overlay_path).map_err(|e| e.to_string())?;
+    let overlay_header_record = overlay_reader.headers().map_err(|e| e.to_string())?.clone();
+    let overlay_headers = overlay_header_record
+        .into_iter()
+        .enumerate()
+        .map(|(i, s)| (s, i))
+        .collect::<HashMap<_, _>>();
+    let overlay_geom_idx = overlay_headers
+        .get(geometry_column)
+        .ok_or_else(|| format!("overlay file missing {geometry_column} column"))?;
+    let overlay_id_idx = overlay_headers
+        .get(id_column)
+        .ok_or_else(|| format!("overlay file missing {id_column} column"))?;
+
+    let overlay_data = overlay_reader
+        .records()
+        .enumerate()
+        .map(|(idx, r)| {
+            let row = r.map_err(|e| e.to_string())?;
+            let geometry_str = row
+                .get(*overlay_geom_idx)
+                .ok_or_else(|| format!("row {idx} missing geometry index"))?;
+            let geometry = wkt::Wkt(geometry_str).to_geo().map_err(|e| e.to_string())?;
+            let id = row
+                .get(*overlay_id_idx)
+                .ok_or_else(|| format!("row {idx} missing id index"))?
+                .to_string();
+
+            match geometry {
+                Geometry::Point(_) => Err(format!(
+                    "unexpected Point geometry type for row {idx} with id {id}"
+                )),
+                Geometry::Line(_) => Err(format!(
+                    "unexpected Line geometry type for row {idx} with id {id}"
+                )),
+                Geometry::LineString(_) => Err(format!(
+                    "unexpected LineString geometry type for row {idx} with id {id}"
+                )),
+                Geometry::Polygon(_) => Ok(()),
+                Geometry::MultiPoint(_) => Err(format!(
+                    "unexpected MultiPoint geometry type for row {idx} with id {id}"
+                )),
+                Geometry::MultiLineString(_) => Err(format!(
+                    "unexpected MultiLineString geometry type for row {idx} with id {id}"
+                )),
+                Geometry::MultiPolygon(_) => Ok(()),
+                Geometry::GeometryCollection(_) => Err(format!(
+                    "unexpected GeometryCollection geometry type for row {idx} with id {id}"
+                )),
+                Geometry::Rect(_) => Err(format!(
+                    "unexpected Rect geometry type for row {idx} with id {id}"
+                )),
+                Geometry::Triangle(_) => Err(format!(
+                    "unexpected Triangle geometry type for row {idx} with id {id}"
+                )),
+            }?;
+
+            Ok((geometry, id))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(overlay_data)
+}

--- a/rust/bambam/src/bin/bambam_util.rs
+++ b/rust/bambam/src/bin/bambam_util.rs
@@ -149,18 +149,21 @@ pub enum App {
     OverlayShapefile {
         /// a CSV file containing a bambam output
         bambam_output_filepath: String,
-        /// a shapefile such as a
+        /// a path to the overlay boundary dataset, such as a shapefile
         overlay_filepath: String,
         /// file path to write the result dataset
         output_directory: String,
         /// used for specifying column name for the geometry x value. do not combine with
         /// geometry_column argument.
+        #[arg(long)]
         xcol: Option<String>,
         /// used for specifying column name for the geometry y value. do not combine with
         /// geometry_column argument.
+        #[arg(long)]
         ycol: Option<String>,
         /// used for specifying column name for the geometry. do not combine with x_column or
         /// y_column arguments.
+        #[arg(long)]
         geomcol: Option<String>,
         /// overlay method to apply
         #[arg(long, default_value_t = OverlayOperation::Intersection)]
@@ -170,6 +173,9 @@ pub enum App {
         /// removing values such as forward slashes that could have unintended effects.
         #[arg(long, default_value_t = String::from("GEOID"))]
         id_field: String,
+        /// if true, log if any rows fail to match the provided overlay dataset
+        #[arg(long)]
+        verbose: bool,
     },
     #[command(
         name = "gtfs-config",
@@ -361,6 +367,7 @@ impl App {
                 geomcol: geometry_column,
                 how,
                 id_field,
+                verbose,
             } => {
                 let col_type = GeometryColumnType::new(
                     x_column.as_ref(),
@@ -378,6 +385,7 @@ impl App {
                     &overlay_source,
                     &col_type,
                     how,
+                    *verbose,
                 )
             }
         }

--- a/rust/bambam/src/bin/bambam_util.rs
+++ b/rust/bambam/src/bin/bambam_util.rs
@@ -170,7 +170,7 @@ pub enum App {
         /// used for specifying the geometry type of the value stored at geomcol do not combine
         /// with xcol or ycol arguments.
         #[arg(long)]
-        geomformat: Option<GeometryFormat>,
+        geomfmt: Option<GeometryFormat>,
         /// overlay method to apply
         #[arg(long, default_value_t = OverlayOperation::Intersection)]
         how: OverlayOperation,
@@ -372,7 +372,7 @@ impl App {
                 xcol: x_column,
                 ycol: y_column,
                 geomcol,
-                geomformat,
+                geomfmt: geomformat,
                 how,
                 id_field,
                 verbose,

--- a/rust/bambam/src/bin/bambam_util.rs
+++ b/rust/bambam/src/bin/bambam_util.rs
@@ -1,5 +1,7 @@
 use bambam::app::oppvec::{self, oppvec_ops};
-use bambam::app::overlay::{self, GeometryColumnType, OverlayOperation, OverlaySource};
+use bambam::app::overlay::{
+    self, GeometryColumnType, GeometryFormat, OverlayOperation, OverlaySource,
+};
 use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -154,17 +156,21 @@ pub enum App {
         /// file path to write the result dataset
         output_directory: String,
         /// used for specifying column name for the geometry x value. do not combine with
-        /// geometry_column argument.
+        /// geomcol argument.
         #[arg(long)]
         xcol: Option<String>,
         /// used for specifying column name for the geometry y value. do not combine with
-        /// geometry_column argument.
+        /// geomcol argument.
         #[arg(long)]
         ycol: Option<String>,
-        /// used for specifying column name for the geometry. do not combine with x_column or
-        /// y_column arguments.
+        /// used for specifying column name for the geometry. do not combine with xcol or
+        /// ycol arguments.
         #[arg(long)]
         geomcol: Option<String>,
+        /// used for specifying the geometry type of the value stored at geomcol do not combine
+        /// with xcol or ycol arguments.
+        #[arg(long)]
+        geomformat: Option<GeometryFormat>,
         /// overlay method to apply
         #[arg(long, default_value_t = OverlayOperation::Intersection)]
         how: OverlayOperation,
@@ -358,13 +364,15 @@ impl App {
                 base_config_relative_path.as_deref(),
             )
             .map_err(|e| e.to_string()),
+
             Self::OverlayShapefile {
                 bambam_output_filepath,
                 overlay_filepath,
                 output_directory,
                 xcol: x_column,
                 ycol: y_column,
-                geomcol: geometry_column,
+                geomcol,
+                geomformat,
                 how,
                 id_field,
                 verbose,
@@ -372,8 +380,8 @@ impl App {
                 let col_type = GeometryColumnType::new(
                     x_column.as_ref(),
                     y_column.as_ref(),
-                    geometry_column.as_ref(),
-                    None,
+                    geomcol.as_ref(),
+                    geomformat.as_ref(),
                 )?;
                 let overlay_source = OverlaySource::Shapefile {
                     file: overlay_filepath.clone(),

--- a/rust/bambam/src/bin/bambam_util.rs
+++ b/rust/bambam/src/bin/bambam_util.rs
@@ -1,6 +1,6 @@
 use bambam::app::oppvec::{self, oppvec_ops};
 use bambam::app::overlay::{
-    self, GeometryColumnType, GeometryFormat, OverlayOperation, OverlaySource,
+    self, GeometryColumnType, OverlayOperation, OverlaySource,
 };
 use clap::{Parser, Subcommand};
 #[derive(Parser)]

--- a/rust/bambam/src/bin/bambam_util.rs
+++ b/rust/bambam/src/bin/bambam_util.rs
@@ -1,4 +1,7 @@
 use bambam::app::oppvec::{self, oppvec_ops};
+use bambam::app::overlay::{
+    self, GeometryColumnType, GeometryFormat, OverlayOperation, OverlaySource,
+};
 use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -140,6 +143,35 @@ pub enum App {
         // /// comma-delimited list of categories to keep
         // #[arg(long)]
         // activity_categories: String,
+    },
+    #[command(
+        name = "overlay-shapefile",
+        about = "partition the BAMBAM output into another dataset of geospatial boundaries"
+    )]
+    OverlayShapefile {
+        /// a CSV file containing a bambam output
+        bambam_output_filepath: String,
+        /// a shapefile such as a
+        overlay_filepath: String,
+        /// file path to write the result dataset
+        output_directory: String,
+        /// used for specifying column name for the geometry x value. do not combine with
+        /// geometry_column argument.
+        x_column: Option<String>,
+        /// used for specifying column name for the geometry y value. do not combine with
+        /// geometry_column argument.
+        y_column: Option<String>,
+        /// used for specifying column name for the geometry. do not combine with x_column or
+        /// y_column arguments.
+        geometry_column: Option<String>,
+        /// overlay method to apply
+        #[arg(long, default_value_t = OverlayOperation::Intersection)]
+        how: OverlayOperation,
+        /// name of the id field in the shapefile, used to create the output filepath
+        /// for each partitioned dataset. values will be re-encoded for the filesystem,
+        /// removing values such as forward slashes that could have unintended effects.
+        #[arg(long, default_value_t = String::from("GEOID"))]
+        id_field: String,
     },
     #[command(
         name = "gtfs-config",
@@ -322,6 +354,34 @@ impl App {
                 base_config_relative_path.as_deref(),
             )
             .map_err(|e| e.to_string()),
+            Self::OverlayShapefile {
+                bambam_output_filepath,
+                overlay_filepath,
+                output_directory,
+                x_column,
+                y_column,
+                geometry_column,
+                how,
+                id_field,
+            } => {
+                let col_type = GeometryColumnType::new(
+                    x_column.as_ref(),
+                    y_column.as_ref(),
+                    geometry_column.as_ref(),
+                    None,
+                )?;
+                let overlay_source = OverlaySource::Shapefile {
+                    file: overlay_filepath.clone(),
+                    id_field: id_field.clone(),
+                };
+                overlay::run(
+                    bambam_output_filepath,
+                    output_directory,
+                    &overlay_source,
+                    &col_type,
+                    how,
+                )
+            }
         }
     }
 }

--- a/rust/bambam/src/bin/bambam_util.rs
+++ b/rust/bambam/src/bin/bambam_util.rs
@@ -1,7 +1,5 @@
 use bambam::app::oppvec::{self, oppvec_ops};
-use bambam::app::overlay::{
-    self, GeometryColumnType, OverlayOperation, OverlaySource,
-};
+use bambam::app::overlay::{self, GeometryColumnType, OverlayOperation, OverlaySource};
 use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -157,13 +155,13 @@ pub enum App {
         output_directory: String,
         /// used for specifying column name for the geometry x value. do not combine with
         /// geometry_column argument.
-        x_column: Option<String>,
+        xcol: Option<String>,
         /// used for specifying column name for the geometry y value. do not combine with
         /// geometry_column argument.
-        y_column: Option<String>,
+        ycol: Option<String>,
         /// used for specifying column name for the geometry. do not combine with x_column or
         /// y_column arguments.
-        geometry_column: Option<String>,
+        geomcol: Option<String>,
         /// overlay method to apply
         #[arg(long, default_value_t = OverlayOperation::Intersection)]
         how: OverlayOperation,
@@ -358,9 +356,9 @@ impl App {
                 bambam_output_filepath,
                 overlay_filepath,
                 output_directory,
-                x_column,
-                y_column,
-                geometry_column,
+                xcol: x_column,
+                ycol: y_column,
+                geomcol: geometry_column,
                 how,
                 id_field,
             } => {


### PR DESCRIPTION
@yamilbknsu this PR brings back an overlay app to bambam. it takes as an argument an output CSV, column names for the geometries (`--xcol lon --ycol lat`), an overlay shapefile (.shp), an identifier column, and a target output directory. it can be used to overlay a dataset such as [this one](https://www2.census.gov/geo/tiger/TIGER2024/UAC20/) over a bambam output. the id_column sets the name of each partitioned output CSV file. that's the idea at least, not yet tested!