### PR TITLE
compass 0.19.3

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ bamcensus-acs = { version = "0.1.0" }
 bamcensus-core = { version = "0.1.0" }
 bamcensus-lehd = { version = "0.1.0" }
 chrono = { version = "0.4.42", features = ["serde"] }
-clap = { version = "4.3.19", features = ["derive"] }
+clap = { version = "4.5.52", features = ["derive"] }
 config = "0.15.19"
 csv = "1.3.1"
 downloader = { version = "0.2.8" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,11 +52,11 @@ rand = "0.10.0"
 rayon = "1.10.0"
 regex = { version = "1.11.1" }
 reqwest = { version = "0.12.12", features = ["blocking"] }
-routee-compass = { version = "0.19.2" }
-routee-compass-core = { version = "0.19.2" }
-routee-compass-macros = { version = "0.19.2" }
-routee-compass-powertrain = { version = "0.19.2" }
-routee-compass-py = { version = "0.19.2" }
+routee-compass = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature", default-features = false }
+routee-compass-core = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
+routee-compass-macros = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
+# routee-compass-powertrain = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
+routee-compass-py = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
 rstar = { version = "0.12.2" }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_arrow = { version = "0.14.0", features = ["arrow-58"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,11 +52,11 @@ rand = "0.10.0"
 rayon = "1.10.0"
 regex = { version = "1.11.1" }
 reqwest = { version = "0.12.12", features = ["blocking"] }
-routee-compass = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature", default-features = false }
-routee-compass-core = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
-routee-compass-macros = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
-# routee-compass-powertrain = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
-routee-compass-py = { git = "https://github.com/NatLabRockies/routee-compass.git", branch = "rjf/powertrain-feature" }
+routee-compass = { version = "0.19.3", default-features = false }
+routee-compass-core = { version = "0.19.3" }
+routee-compass-macros = { version = "0.19.3" }
+# routee-compass-powertrain = { version = "0.19.3" }
+routee-compass-py = { version = "0.19.3" }
 rstar = { version = "0.12.2" }
 sanitize-filename = "0.6.0"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/rust/bambam-core/Cargo.toml
+++ b/rust/bambam-core/Cargo.toml
@@ -22,7 +22,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 routee-compass = { workspace = true }
 routee-compass-core = { workspace = true }
-routee-compass-powertrain = { workspace = true }
+# routee-compass-powertrain = { workspace = true }
 rstar = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/bambam-core/src/model/bambam_state.rs
+++ b/rust/bambam-core/src/model/bambam_state.rs
@@ -25,4 +25,4 @@ pub const DWELL_TIME: &str = "dwell_time";
 pub const COST_PENALTY_FACTOR: &str = "penalty_factor";
 
 pub use routee_compass_core::model::traversal::default::fieldname::*;
-pub use routee_compass_powertrain::model::fieldname::*;
+// pub use routee_compass_powertrain::model::fieldname::*;

--- a/rust/bambam-gbfs/src/model/constraint/boarding/model.rs
+++ b/rust/bambam-gbfs/src/model/constraint/boarding/model.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use routee_compass_core::model::constraint::ConstraintModel;
+use routee_compass_core::model::{
+    constraint::ConstraintModel,
+    state::{StateModel, StateVariable},
+    traversal::EdgeFrontierContext,
+};
 
 use super::BoardingConstraintEngine;
 
@@ -18,10 +22,9 @@ impl BoardingConstraintModel {
 impl ConstraintModel for BoardingConstraintModel {
     fn valid_frontier(
         &self,
-        _edge: &routee_compass_core::model::network::Edge,
-        _previous_edge: Option<&routee_compass_core::model::network::Edge>,
-        _state: &[routee_compass_core::model::state::StateVariable],
-        _state_model: &routee_compass_core::model::state::StateModel,
+        _ctx: &EdgeFrontierContext,
+        _state: &[StateVariable],
+        _state_model: &StateModel,
     ) -> Result<bool, routee_compass_core::model::constraint::ConstraintModelError> {
         todo!()
     }

--- a/rust/bambam-gbfs/src/model/constraint/geofence/model.rs
+++ b/rust/bambam-gbfs/src/model/constraint/geofence/model.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use routee_compass_core::model::constraint::ConstraintModel;
+use routee_compass_core::model::{
+    constraint::ConstraintModel,
+    state::{StateModel, StateVariable},
+    traversal::EdgeFrontierContext,
+};
 
 use crate::model::constraint::geofence::GeofenceConstraintEngine;
 
@@ -19,10 +23,9 @@ impl GeofenceConstraintModel {
 impl ConstraintModel for GeofenceConstraintModel {
     fn valid_frontier(
         &self,
-        _edge: &routee_compass_core::model::network::Edge,
-        _previous_edge: Option<&routee_compass_core::model::network::Edge>,
-        _state: &[routee_compass_core::model::state::StateVariable],
-        _state_model: &routee_compass_core::model::state::StateModel,
+        _ctx: &EdgeFrontierContext,
+        _state: &[StateVariable],
+        _state_model: &StateModel,
     ) -> Result<bool, routee_compass_core::model::constraint::ConstraintModelError> {
         todo!()
     }

--- a/rust/bambam-gbfs/src/model/traversal/boarding/model.rs
+++ b/rust/bambam-gbfs/src/model/traversal/boarding/model.rs
@@ -3,7 +3,7 @@ use routee_compass_core::{
     model::{
         network::Vertex,
         state::{InputFeature, StateModel, StateVariable, StateVariableConfig},
-        traversal::{EdgeTraversalContext, TraversalModel, TraversalModelError},
+        traversal::{EdgeFrontierContext, TraversalModel, TraversalModelError},
     },
 };
 
@@ -36,7 +36,7 @@ impl TraversalModel for BoardingTraversalModel {
 
     fn traverse_edge(
         &self,
-        _ctx: &EdgeTraversalContext,
+        _ctx: &EdgeFrontierContext,
         _state: &mut Vec<StateVariable>,
         _state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {

--- a/rust/bambam-gtfs-flex/src/model/constraint/model.rs
+++ b/rust/bambam-gtfs-flex/src/model/constraint/model.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use routee_compass_core::model::constraint::ConstraintModel;
+use routee_compass_core::model::{
+    constraint::ConstraintModel,
+    state::{StateModel, StateVariable},
+    traversal::EdgeFrontierContext,
+};
 
 use crate::util::zone::ZoneLookup;
 
@@ -18,10 +22,9 @@ impl GtfsFlexDepartureConstraintModel {
 impl ConstraintModel for GtfsFlexDepartureConstraintModel {
     fn valid_frontier(
         &self,
-        _edge: &routee_compass_core::model::network::Edge,
-        _previous_edge: Option<&routee_compass_core::model::network::Edge>,
-        _state: &[routee_compass_core::model::state::StateVariable],
-        _state_model: &routee_compass_core::model::state::StateModel,
+        _ctx: &EdgeFrontierContext,
+        _state: &[StateVariable],
+        _state_model: &StateModel,
     ) -> Result<bool, routee_compass_core::model::constraint::ConstraintModelError> {
         // have we transitioned onto this travel mode yet?
         // if not, we are boarding GTFS-Flex. check if the ZoneGraph would

--- a/rust/bambam-gtfs-flex/src/model/traversal/flex/model.rs
+++ b/rust/bambam-gtfs-flex/src/model/traversal/flex/model.rs
@@ -9,7 +9,7 @@ use routee_compass_core::{
     model::{
         network::Vertex,
         state::{InputFeature, StateModel, StateVariable, StateVariableConfig},
-        traversal::{EdgeTraversalContext, TraversalModel, TraversalModelError},
+        traversal::{EdgeFrontierContext, TraversalModel, TraversalModelError},
     },
 };
 
@@ -41,7 +41,7 @@ impl TraversalModel for GtfsFlexModel {
 
     fn traverse_edge(
         &self,
-        _ctx: &EdgeTraversalContext,
+        _ctx: &EdgeFrontierContext,
         _state: &mut Vec<StateVariable>,
         _state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {

--- a/rust/bambam-gtfs/src/schedule/app/operation.rs
+++ b/rust/bambam-gtfs/src/schedule/app/operation.rs
@@ -320,7 +320,7 @@ fn summarize(rows: &Vec<GtfsProvider>) {
                         for pair in trip.stop_times.windows(2) {
                             leg_ods.insert((&pair[0].stop.id, &pair[1].stop.id));
                         }
-                        let trip_legs = (trip.stop_times.len() - 1).max(0); // stop_times are vertices, we want edges
+                        let trip_legs = trip.stop_times.len() - 1; // stop_times are vertices, we want edges
                         n_legs += trip_legs;
                         n_unique_legs += leg_ods.len();
 

--- a/rust/bambam-gtfs/src/schedule/app/operation.rs
+++ b/rust/bambam-gtfs/src/schedule/app/operation.rs
@@ -316,6 +316,9 @@ fn summarize(rows: &Vec<GtfsProvider>) {
                     let mut n_unique_legs = 0;
                     let mut sum = 0;
                     for (_, trip) in gtfs.trips {
+                        if trip.stop_times.len() < 2 {
+                            continue; // ignore invalid trips with 0 or 1 stop times
+                        }
                         let mut leg_ods: HashSet<(&String, &String)> = HashSet::new();
                         for pair in trip.stop_times.windows(2) {
                             leg_ods.insert((&pair[0].stop.id, &pair[1].stop.id));

--- a/rust/bambam-omf/Cargo.toml
+++ b/rust/bambam-omf/Cargo.toml
@@ -41,7 +41,7 @@ rayon = { workspace = true }
 reqwest = { workspace = true }
 routee-compass = { workspace = true }
 routee-compass-core = { workspace = true }
-routee-compass-powertrain = { workspace = true }
+# routee-compass-powertrain = { workspace = true }
 serde = { workspace = true }
 serde_arrow = { workspace = true }
 serde_bytes = { workspace = true }

--- a/rust/bambam-osm/Cargo.toml
+++ b/rust/bambam-osm/Cargo.toml
@@ -36,7 +36,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 routee-compass = { workspace = true }
 routee-compass-core = { workspace = true }
-routee-compass-powertrain = { workspace = true }
+# routee-compass-powertrain = { workspace = true }
 rstar = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/bambam/Cargo.toml
+++ b/rust/bambam/Cargo.toml
@@ -48,7 +48,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 routee-compass = { workspace = true }
 routee-compass-core = { workspace = true }
-routee-compass-powertrain = { workspace = true }
+# routee-compass-powertrain = { workspace = true }
 
 rstar = { workspace = true }
 

--- a/rust/bambam/src/app/gtfs_config/run.rs
+++ b/rust/bambam/src/app/gtfs_config/run.rs
@@ -27,7 +27,7 @@ use crate::{
     model::{
         constraint::{
             multimodal::{ConstraintConfig, MultimodalConstraintConfig},
-            time_limit::{TimeLimitConfig, TimeLimitConstraintConfig},
+            time_limit::{TimeLimit, TimeLimitConstraintConfig},
         },
         traversal::{
             multimodal::MultimodalTraversalConfig,
@@ -406,7 +406,7 @@ pub fn gtfs_traversal_model_config(
 
 /// generates the JSON fields expected for a transit frontier model
 pub fn gtfs_constraint_model_config(
-    time_limit: &TimeLimitConfig,
+    time_limit: &TimeLimit,
     available_modes: &[String],
 ) -> Result<serde_json::Value, GtfsConfigError> {
     let mmc_conf = MultimodalConstraintConfig {

--- a/rust/bambam/src/model/constraint/multimodal/constraint.rs
+++ b/rust/bambam/src/model/constraint/multimodal/constraint.rs
@@ -187,7 +187,7 @@ impl TryFrom<&ConstraintConfig> for Constraint {
                         })?;
                         Ok((k.clone(), v_usize))
                     })
-                    .collect::<Result<HashMap<_, _>, _>>()?;
+                    .collect::<Result<HashMap<_, _>, ConstraintModelError>>()?;
                 Ok(Self::ModeCounts(counts))
             }
             MFCC::ExactSequences { values } => {

--- a/rust/bambam/src/model/constraint/multimodal/model.rs
+++ b/rust/bambam/src/model/constraint/multimodal/model.rs
@@ -6,6 +6,7 @@ use crate::model::constraint::multimodal::{ConstraintConfig, MultimodalConstrain
 use bambam_core::model::state::{
     multimodal_state_ops as state_ops, LegIdx, MultimodalMapping, MultimodalStateMapping,
 };
+use routee_compass_core::model::traversal::EdgeFrontierContext;
 use routee_compass_core::model::{
     constraint::{ConstraintModel, ConstraintModelError},
     network::Edge,
@@ -58,65 +59,73 @@ impl MultimodalConstraintModel {
 }
 
 impl ConstraintModel for MultimodalConstraintModel {
-    /// confirms that, upon reaching this edge,
-    ///   - we have not exceeded any mode-specific distance, time or energy limit
-    ///     confirms that, if we add this edge,
-    ///   - we have not exceeded max trip legs
-    ///   - we have not exceeded max mode counts
-    ///   - our trip still matches any exact mode sequences
     fn valid_frontier(
         &self,
-        edge: &Edge,
-        previous_edge: Option<&Edge>,
+        ctx: &EdgeFrontierContext,
         state: &[StateVariable],
         state_model: &StateModel,
     ) -> Result<bool, ConstraintModelError> {
-        // if adding this edge would exceed max_trip_legs, we can skip running the constraints
-        // and directly reject this edge.
-        let valid_leg_count = state_ops::appending_edge_mode_is_valid(
-            state,
-            state_model,
-            &self.engine.mode,
-            self.max_trip_legs,
-            &self.engine.mode_to_state,
-        )
-        .map_err(|e| {
-            let msg = format!("in multimodal constraint model, {e}");
-            ConstraintModelError::ConstraintModelError(msg)
-        })?;
-        if !valid_leg_count {
-            return Ok(false);
-        }
-
-        for constraint in self.constraints.iter() {
-            let valid = constraint.valid_frontier(
-                &self.engine.mode,
-                edge,
-                state,
-                state_model,
-                &self.engine.mode_to_state,
-                self.max_trip_legs,
-            )?;
-            log::debug!(
-                "multimodal frontier is valid? '{valid}' for edge {:?} with active_leg {}, trip_time: {:.2} minutes",
-                (edge.edge_list_id, edge.edge_id),
-                state_ops::get_active_leg_idx(state, state_model).unwrap_or_default().unwrap_or_default(),
-                state_model
-                    .get_time(state, "trip_time")
-                    .unwrap_or_default()
-                    .get::<uom::si::time::minute>(),
-            );
-            if !valid {
-                return Ok(false);
-            }
-        }
-
-        Ok(true)
+        validate_frontier(ctx.edge, state, state_model, self)
     }
 
     fn valid_edge(&self, edge: &Edge) -> Result<bool, ConstraintModelError> {
         Ok(true)
     }
+}
+
+/// confirms that, upon reaching this edge,
+///   - we have not exceeded any mode-specific distance, time or energy limit
+///     confirms that, if we add this edge,
+///   - we have not exceeded max trip legs
+///   - we have not exceeded max mode counts
+///   - our trip still matches any exact mode sequences
+fn validate_frontier(
+    edge: &Edge,
+    state: &[StateVariable],
+    state_model: &StateModel,
+    model: &MultimodalConstraintModel,
+) -> Result<bool, ConstraintModelError> {
+    // if adding this edge would exceed max_trip_legs, we can skip running the constraints
+    // and directly reject this edge.
+    let valid_leg_count = state_ops::appending_edge_mode_is_valid(
+        state,
+        state_model,
+        &model.engine.mode,
+        model.max_trip_legs,
+        &model.engine.mode_to_state,
+    )
+    .map_err(|e| {
+        let msg = format!("in multimodal constraint model, {e}");
+        ConstraintModelError::ConstraintModelError(msg)
+    })?;
+    if !valid_leg_count {
+        return Ok(false);
+    }
+
+    for constraint in model.constraints.iter() {
+        let valid = constraint.valid_frontier(
+            &model.engine.mode,
+            edge,
+            state,
+            state_model,
+            &model.engine.mode_to_state,
+            model.max_trip_legs,
+        )?;
+        log::debug!(
+            "multimodal frontier is valid? '{valid}' for edge {:?} with active_leg {}, trip_time: {:.2} minutes",
+            (edge.edge_list_id, edge.edge_id),
+            state_ops::get_active_leg_idx(state, state_model).unwrap_or_default().unwrap_or_default(),
+            state_model
+                .get_time(state, "trip_time")
+                .unwrap_or_default()
+                .get::<uom::si::time::minute>(),
+        );
+        if !valid {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -137,7 +146,9 @@ mod test {
 
     use crate::model::{
         constraint::multimodal::{
-            model::MultimodalConstraintModel, sequence_trie::SubSequenceTrie, Constraint,
+            model::{validate_frontier, MultimodalConstraintModel},
+            sequence_trie::SubSequenceTrie,
+            Constraint,
         },
         traversal::multimodal::MultimodalTraversalModel,
     };
@@ -153,9 +164,7 @@ mod test {
         let edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
 
         // test
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -175,9 +184,7 @@ mod test {
             .expect("test invariant failed");
 
         // test
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -199,9 +206,7 @@ mod test {
         );
 
         // test
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -239,9 +244,7 @@ mod test {
             1,
             Length::new::<uom::si::length::meter>(1000.0),
         );
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -272,9 +275,7 @@ mod test {
 
         // test accessing another walk-mode link, which would increase the number of walk-mode legs to 3
         let edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -309,9 +310,7 @@ mod test {
             1,
             Length::new::<uom::si::length::meter>(1000.0),
         );
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -339,9 +338,7 @@ mod test {
 
         // test the drive-mode traversal model, which is not an allowed mode
         let edge = Edge::new(2, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -373,9 +370,7 @@ mod test {
             1,
             Length::new::<uom::si::length::meter>(1000.0),
         );
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -415,9 +410,7 @@ mod test {
             1,
             Length::new::<uom::si::length::meter>(1000.0),
         );
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -448,9 +441,7 @@ mod test {
         );
 
         // test
-        let is_valid = mfm
-            .valid_frontier(&edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid = validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -511,9 +502,8 @@ mod test {
 
         // Test that walk-mode edge is invalid when walk has 0 limit
         let walk_edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = walk_mfm
-            .valid_frontier(&walk_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&walk_edge, &state, &state_model, &walk_mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -534,9 +524,8 @@ mod test {
 
         // Test drive-mode edge traversal model when drive is not in limits
         let dummy_edge = Edge::new(2, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&dummy_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&dummy_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -562,9 +551,8 @@ mod test {
 
         // Test adding another walk edge (same mode) - should be valid
         let walk_edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&walk_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&walk_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -587,9 +575,8 @@ mod test {
                 1,
                 Length::new::<uom::si::length::meter>(1000.0),
             );
-            let is_valid = mfm
-                .valid_frontier(&edge, None, &state, &state_model)
-                .expect("test failed");
+            let is_valid =
+                validate_frontier(&edge, &state, &state_model, &mfm).expect("test failed");
             assert!(!is_valid);
         }
     }
@@ -609,9 +596,8 @@ mod test {
         );
 
         let walk_edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0)); // lowercase walk
-        let is_valid = mfm
-            .valid_frontier(&walk_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&walk_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid); // Should be invalid due to case mismatch
     }
 
@@ -640,9 +626,8 @@ mod test {
 
         // Test walk edge - should be valid as "bike" -> "walk" is a valid sequence
         let walk_edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&walk_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&walk_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -660,9 +645,8 @@ mod test {
         );
 
         let walk_edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&walk_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&walk_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid);
     }
 
@@ -695,9 +679,8 @@ mod test {
 
         // Test bike edge - should be valid as we're continuing the valid sequence
         let bike_edge = Edge::new(1, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&bike_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&bike_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -724,9 +707,8 @@ mod test {
         );
 
         let bike_edge = Edge::new(1, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&bike_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&bike_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(is_valid);
     }
 
@@ -754,9 +736,8 @@ mod test {
         );
 
         let bike_edge = Edge::new(1, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = bike_mfm
-            .valid_frontier(&bike_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&bike_edge, &state, &state_model, &bike_mfm).expect("test failed");
         assert!(!is_valid); // Should fail due to AllowedModes constraint
     }
 
@@ -789,9 +770,8 @@ mod test {
 
         // Since we have 26 walk legs and the limit is 25, another walk edge should be invalid
         let walk_edge = Edge::new(0, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = mfm
-            .valid_frontier(&walk_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&walk_edge, &state, &state_model, &mfm).expect("test failed");
         assert!(!is_valid); // Should be invalid as we've exceeded the walk limit
     }
 
@@ -813,9 +793,8 @@ mod test {
 
         // Test adding a different mode edge, which would create a second leg and exceed the limit
         let bike_edge = Edge::new(1, 0, 0, 1, Length::new::<uom::si::length::meter>(1000.0));
-        let is_valid = bike_mfm
-            .valid_frontier(&bike_edge, None, &state, &state_model)
-            .expect("test failed");
+        let is_valid =
+            validate_frontier(&bike_edge, &state, &state_model, &bike_mfm).expect("test failed");
         assert!(!is_valid); // Should be invalid as this would create a second leg
     }
 }

--- a/rust/bambam/src/model/constraint/multimodal/model.rs
+++ b/rust/bambam/src/model/constraint/multimodal/model.rs
@@ -68,7 +68,7 @@ impl ConstraintModel for MultimodalConstraintModel {
         validate_frontier(ctx.edge, state, state_model, self)
     }
 
-    fn valid_edge(&self, edge: &Edge) -> Result<bool, ConstraintModelError> {
+    fn valid_edge(&self, _edge: &Edge) -> Result<bool, ConstraintModelError> {
         Ok(true)
     }
 }

--- a/rust/bambam/src/model/constraint/time_limit/builder.rs
+++ b/rust/bambam/src/model/constraint/time_limit/builder.rs
@@ -1,6 +1,6 @@
-use crate::model::constraint::time_limit::{TimeLimitConfig, TimeLimitConstraintConfig};
+use crate::model::constraint::time_limit::{TimeLimit, TimeLimitConstraintConfig};
 
-use super::time_limit_frontier_service::TimeLimitConstraintService;
+use super::service::TimeLimitConstraintService;
 use routee_compass_core::model::{
     constraint::{ConstraintModelBuilder, ConstraintModelError, ConstraintModelService},
     unit::TimeUnit,

--- a/rust/bambam/src/model/constraint/time_limit/config.rs
+++ b/rust/bambam/src/model/constraint/time_limit/config.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::model::constraint::time_limit::TimeLimitConfig;
+use crate::model::constraint::time_limit::TimeLimit;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TimeLimitConstraintConfig {
-    pub time_limit: TimeLimitConfig,
+    pub time_limit: TimeLimit,
 }

--- a/rust/bambam/src/model/constraint/time_limit/mod.rs
+++ b/rust/bambam/src/model/constraint/time_limit/mod.rs
@@ -1,13 +1,13 @@
-mod time_limit_config;
-mod time_limit_frontier_builder;
-mod time_limit_frontier_config;
-mod time_limit_frontier_model;
-mod time_limit_frontier_service;
+mod builder;
+mod config;
+mod model;
+mod service;
+mod time_limit;
 
-pub use time_limit_config::TimeLimitConfig;
-pub use time_limit_frontier_builder::TimeLimitConstraintBuilder;
-pub use time_limit_frontier_config::TimeLimitConstraintConfig;
-pub use time_limit_frontier_model::TimeLimitConstraintModel;
-pub use time_limit_frontier_service::TimeLimitConstraintService;
+pub use builder::TimeLimitConstraintBuilder;
+pub use config::TimeLimitConstraintConfig;
+pub use model::TimeLimitConstraintModel;
+pub use service::TimeLimitConstraintService;
+pub use time_limit::TimeLimit;
 
 pub const TIME_LIMIT_FIELD: &str = "time_limit";

--- a/rust/bambam/src/model/constraint/time_limit/model.rs
+++ b/rust/bambam/src/model/constraint/time_limit/model.rs
@@ -1,4 +1,4 @@
-use crate::model::constraint::time_limit::TimeLimitConfig;
+use crate::model::constraint::time_limit::TimeLimit;
 use bambam_core::model::bambam_state;
 use routee_compass_core::{
     algorithm::search::Direction,
@@ -6,6 +6,7 @@ use routee_compass_core::{
         constraint::{ConstraintModel, ConstraintModelError},
         network::{Edge, VertexId},
         state::{StateModel, StateVariable},
+        traversal::EdgeFrontierContext,
         unit::TimeUnit,
     },
 };
@@ -19,8 +20,7 @@ pub struct TimeLimitConstraintModel {
 impl ConstraintModel for TimeLimitConstraintModel {
     fn valid_frontier(
         &self,
-        _edge: &Edge,
-        _previous_edge: Option<&Edge>,
+        _ctx: &EdgeFrontierContext,
         state: &[StateVariable],
         state_model: &StateModel,
     ) -> Result<bool, ConstraintModelError> {

--- a/rust/bambam/src/model/constraint/time_limit/service.rs
+++ b/rust/bambam/src/model/constraint/time_limit/service.rs
@@ -1,6 +1,6 @@
-use crate::model::constraint::time_limit::{TimeLimitConfig, TimeLimitConstraintConfig};
+use crate::model::constraint::time_limit::{TimeLimit, TimeLimitConstraintConfig};
 
-use super::time_limit_frontier_model::TimeLimitConstraintModel;
+use super::model::TimeLimitConstraintModel;
 use routee_compass_core::config::ConfigJsonExtensions;
 use routee_compass_core::model::{
     constraint::{ConstraintModel, ConstraintModelError, ConstraintModelService},
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use uom::si::f64::Time;
 
 pub struct TimeLimitConstraintService {
-    time_limit: TimeLimitConfig,
+    time_limit: TimeLimit,
 }
 
 impl TimeLimitConstraintService {
@@ -30,16 +30,12 @@ impl ConstraintModelService for TimeLimitConstraintService {
     ) -> Result<Arc<dyn ConstraintModel>, ConstraintModelError> {
         log::debug!("begin ConstraintModelService::build for TimeLimitConstraintService");
         let conf = match query.get(super::TIME_LIMIT_FIELD) {
+            Some(time_limit_json) => serde_json::from_value(time_limit_json.clone()).map_err(|e| {
+                ConstraintModelError::ConstraintModelError(format!(
+                    "failure reading query time_limit for isochrone frontier model: {e}"
+                ))
+            }),
             None => Ok(self.time_limit.clone()),
-            Some(time_limit_json) => {
-                let time_limit: TimeLimitConfig = serde_json::from_value(time_limit_json.clone())
-                    .map_err(|e| {
-                    ConstraintModelError::ConstraintModelError(format!(
-                        "failure reading query time_limit for isochrone frontier model: {e}"
-                    ))
-                })?;
-                Ok(time_limit)
-            }
         }?;
 
         let time_limit = conf.time_limit()?;

--- a/rust/bambam/src/model/constraint/time_limit/time_limit.rs
+++ b/rust/bambam/src/model/constraint/time_limit/time_limit.rs
@@ -3,12 +3,12 @@ use serde::{Deserialize, Serialize};
 use uom::si::f64::Time;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct TimeLimitConfig {
+pub struct TimeLimit {
     pub time: f64,
     pub time_unit: TimeUnit,
 }
 
-impl TimeLimitConfig {
+impl TimeLimit {
     pub fn time_limit(&self) -> Result<Time, ConstraintModelError> {
         if self.time <= 0.0 {
             Err(ConstraintModelError::BuildError(format!(

--- a/rust/bambam/src/model/traversal/fixed_speed/fixed_speed_model.rs
+++ b/rust/bambam/src/model/traversal/fixed_speed/fixed_speed_model.rs
@@ -7,7 +7,7 @@ use routee_compass_core::{
         network::{Edge, Vertex},
         state::{InputFeature, StateModel, StateVariable, StateVariableConfig},
         traversal::{
-            EdgeTraversalContext, TraversalModel, TraversalModelError, TraversalModelService,
+            EdgeFrontierContext, TraversalModel, TraversalModelError, TraversalModelService,
         },
         unit::SpeedUnit,
     },
@@ -68,7 +68,7 @@ impl TraversalModel for FixedSpeedModel {
 
     fn traverse_edge(
         &self,
-        ctx: &EdgeTraversalContext,
+        _ctx: &EdgeFrontierContext,
         state: &mut Vec<StateVariable>,
         state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {
@@ -78,7 +78,7 @@ impl TraversalModel for FixedSpeedModel {
 
     fn estimate_traversal(
         &self,
-        od: (&Vertex, &Vertex),
+        _od: (&Vertex, &Vertex),
         state: &mut Vec<StateVariable>,
         tree: &SearchTree,
         state_model: &StateModel,

--- a/rust/bambam/src/model/traversal/multimodal/model.rs
+++ b/rust/bambam/src/model/traversal/multimodal/model.rs
@@ -10,7 +10,7 @@ use routee_compass_core::{
         label::Label,
         network::{Edge, Vertex, VertexId},
         state::{InputFeature, StateModel, StateModelError, StateVariable, StateVariableConfig},
-        traversal::{EdgeTraversalContext, TraversalModel, TraversalModelError},
+        traversal::{EdgeFrontierContext, TraversalModel, TraversalModelError},
     },
 };
 use serde_json::json;
@@ -98,7 +98,7 @@ impl TraversalModel for MultimodalTraversalModel {
 
     fn traverse_edge(
         &self,
-        ctx: &EdgeTraversalContext,
+        ctx: &EdgeFrontierContext,
         state: &mut Vec<StateVariable>,
         state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {
@@ -236,7 +236,7 @@ mod test {
         cost::{cost_model_service::CostModelService, CostConstraint, CostModel, VehicleCostRate},
         label::Label,
         network::VertexId,
-        traversal::EdgeTraversalContext,
+        traversal::EdgeFrontierContext,
     };
     use routee_compass_core::{
         algorithm::search::{EdgeTraversal, SearchTree},
@@ -299,7 +299,7 @@ mod test {
         let l = Label::Vertex(VertexId(0));
         let (src, edge, dst) = mock_trajectory(0, 0, 0);
         let tree = SearchTree::default();
-        let ctx = EdgeTraversalContext::new(&l, &src, &edge, &dst, &tree);
+        let ctx = EdgeFrontierContext::new(&l, &src, &edge, &dst, &tree);
 
         mtm.traverse_edge(&ctx, &mut state, &state_model)
             .expect("access failed");
@@ -350,11 +350,11 @@ mod test {
         let l0 = Label::Vertex(VertexId(0));
         let (v0, e0, v1) = mock_trajectory(0, 0, 0);
         let mut tree = SearchTree::default();
-        let ctx1 = EdgeTraversalContext::new(&l0, &v0, &e0, &v1, &tree);
+        let ctx1 = EdgeFrontierContext::new(&l0, &v0, &e0, &v1, &tree);
 
         // traverse walk edge
         let et1 = EdgeTraversal::new_local(
-            ctx1,
+            &ctx1,
             &initial_state,
             &state_model,
             test_walk.as_ref(),
@@ -386,10 +386,10 @@ mod test {
         let l1 = Label::Vertex(VertexId(1));
         let (v1, e1, v2) = mock_trajectory(1, 1, 1);
         let tree = SearchTree::default();
-        let ctx2 = EdgeTraversalContext::new(&l1, &v1, &e1, &v2, &tree);
+        let ctx2 = EdgeFrontierContext::new(&l1, &v1, &e1, &v2, &tree);
 
         let et2 = EdgeTraversal::new_local(
-            ctx2,
+            &ctx2,
             &et1.result_state,
             &state_model,
             test_bike.as_ref(),
@@ -438,16 +438,16 @@ mod test {
         let tree0 = SearchTree::default();
         let l0 = Label::Vertex(VertexId(0));
         let (v0, e0, v1) = mock_trajectory(0, 0, 0);
-        let ctx1 = EdgeTraversalContext::new(&l0, &v0, &e0, &v1, &tree0);
+        let ctx1 = EdgeFrontierContext::new(&l0, &v0, &e0, &v1, &tree0);
         let l1 = Label::Vertex(VertexId(1));
         let (v1, e1, v2) = mock_trajectory(1, 1, 1);
-        let ctx2 = EdgeTraversalContext::new(&l1, &v1, &e1, &v2, &tree0);
+        let ctx2 = EdgeFrontierContext::new(&l1, &v1, &e1, &v2, &tree0);
         // let t1 = mock_trajectory(0, 0, 0);
         // let t2 = mock_trajectory(1, 1, 1);
 
         // establish the trip state on "walk"-mode travel
         let et1 = EdgeTraversal::new_local(
-            ctx1,
+            &ctx1,
             &initial_state,
             &state_model,
             test_walk.as_ref(),
@@ -471,7 +471,7 @@ mod test {
         // ASSERTION 1: trip tries to enter "bike" mode after accessing edge 2 on edge list 1,
         // but this should result in an error, as we have restricted the max number of trip legs to 1.
         let result = EdgeTraversal::new_local(
-            ctx2,
+            &ctx2,
             &et1.result_state,
             &state_model,
             test_bike.as_ref(),
@@ -547,7 +547,7 @@ mod test {
         let l0 = Label::Vertex(VertexId(0));
         let (src, edge, dst) = mock_trajectory(0, 0, 0);
         let tree = SearchTree::default();
-        let ctx = EdgeTraversalContext::new(&l0, &src, &edge, &dst, &tree);
+        let ctx = EdgeFrontierContext::new(&l0, &src, &edge, &dst, &tree);
 
         test_tm
             .traverse_edge(&ctx, &mut state, &state_model)

--- a/rust/bambam/src/model/traversal/schedule/schedule_traversal_model.rs
+++ b/rust/bambam/src/model/traversal/schedule/schedule_traversal_model.rs
@@ -4,8 +4,10 @@ use routee_compass_core::{
     algorithm::search::SearchTree,
     model::{
         network::{Edge, Vertex},
-        state::{CustomVariableConfig, InputFeature, StateVariable, StateVariableConfig},
-        traversal::{TraversalModel, TraversalModelError},
+        state::{
+            CustomVariableConfig, InputFeature, StateModel, StateVariable, StateVariableConfig,
+        },
+        traversal::{EdgeFrontierContext, TraversalModel, TraversalModelError},
     },
 };
 use std::sync::Arc;
@@ -47,16 +49,16 @@ impl TraversalModel for ScheduleTraversalModel {
         _od: (&Vertex, &Vertex),
         _state: &mut Vec<StateVariable>,
         _tree: &SearchTree,
-        _state_model: &routee_compass_core::model::state::StateModel,
+        _state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {
         todo!()
     }
 
     fn traverse_edge(
         &self,
-        ctx: &routee_compass_core::model::traversal::EdgeTraversalContext,
+        ctx: &EdgeFrontierContext,
         state: &mut Vec<StateVariable>,
-        state_model: &routee_compass_core::model::state::StateModel,
+        state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {
         todo!()
     }

--- a/rust/bambam/src/model/traversal/time_delay/trip_arrival_delay_model.rs
+++ b/rust/bambam/src/model/traversal/time_delay/trip_arrival_delay_model.rs
@@ -5,7 +5,9 @@ use routee_compass_core::{
     model::{
         network::{Edge, Vertex},
         state::{InputFeature, StateModel, StateVariable, StateVariableConfig},
-        traversal::{TraversalModel, TraversalModelError, TraversalModelService},
+        traversal::{
+            EdgeFrontierContext, TraversalModel, TraversalModelError, TraversalModelService,
+        },
     },
 };
 use std::sync::Arc;
@@ -65,7 +67,7 @@ impl TraversalModel for TripArrivalDelayModel {
 
     fn traverse_edge(
         &self,
-        ctx: &routee_compass_core::model::traversal::EdgeTraversalContext,
+        ctx: &EdgeFrontierContext,
         state: &mut Vec<StateVariable>,
         state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {

--- a/rust/bambam/src/model/traversal/time_delay/trip_departure_delay_model.rs
+++ b/rust/bambam/src/model/traversal/time_delay/trip_departure_delay_model.rs
@@ -5,7 +5,9 @@ use routee_compass_core::{
     model::{
         network::{Edge, Vertex},
         state::{InputFeature, StateModel, StateVariable, StateVariableConfig},
-        traversal::{TraversalModel, TraversalModelError, TraversalModelService},
+        traversal::{
+            EdgeFrontierContext, TraversalModel, TraversalModelError, TraversalModelService,
+        },
     },
 };
 use std::sync::Arc;
@@ -78,7 +80,7 @@ impl TraversalModel for TripDepartureDelayModel {
 
     fn traverse_edge(
         &self,
-        ctx: &routee_compass_core::model::traversal::EdgeTraversalContext,
+        ctx: &EdgeFrontierContext,
         state: &mut Vec<StateVariable>,
         state_model: &StateModel,
     ) -> Result<(), TraversalModelError> {

--- a/rust/bambam/src/model/traversal/transit/model.rs
+++ b/rust/bambam/src/model/traversal/transit/model.rs
@@ -6,7 +6,7 @@ use bambam_core::model::bambam_state;
 use bambam_core::model::state::variable;
 use chrono::{Duration, NaiveDate, NaiveDateTime};
 use routee_compass_core::model::state::{StateModel, StateVariable};
-use routee_compass_core::model::traversal::{EdgeTraversalContext, TraversalModelError};
+use routee_compass_core::model::traversal::{EdgeFrontierContext, TraversalModelError};
 use routee_compass_core::model::{
     state::StateVariableConfig,
     traversal::{default::fieldname, TraversalModel},
@@ -102,7 +102,7 @@ impl TraversalModel for TransitTraversalModel {
 
     fn traverse_edge(
         &self,
-        ctx: &EdgeTraversalContext,
+        ctx: &EdgeFrontierContext,
         state: &mut Vec<StateVariable>,
         state_model: &StateModel,
     ) -> Result<(), routee_compass_core::model::traversal::TraversalModelError> {


### PR DESCRIPTION
this PR updates bambam to point at the latest version of compass, 0.19.3. this includes:
  - changes to the traversal + constraint model API via the EdgeFrontierContext object
  - the ability to compile a compass dependency without powertrain/onnx dependencies

along the way,
  - the multimodal frontier model logic was moved into it's own function `validate_frontier` in order to avoid having to wrap all mock Edges in an EdgeFrontierContext in the test suites.