### PR TITLE
Rjf/all counts within bin

### DIFF
--- a/rust/bambam-core/src/model/destination/bin.rs
+++ b/rust/bambam-core/src/model/destination/bin.rs
@@ -141,7 +141,7 @@ impl BinningConfig {
         if self.prepend_zero() {
             values.push(0);
         }
-        values.extend(self.values_ascending().into_iter());
+        values.extend(self.values_ascending());
         if values.len() < 2 {
             return Err(DestinationError::InvalidBinConfig {
                 reason: format!(

--- a/rust/bambam-core/src/model/destination/bin.rs
+++ b/rust/bambam-core/src/model/destination/bin.rs
@@ -137,11 +137,12 @@ impl BinningConfig {
     /// * `marginal` - if true, each bin interval will be bounded by two consecutive values in the
     /// binning config. if false, each bin will start with zero.
     pub fn build_bins(&self, marginal: bool) -> Result<Vec<BinInterval>, DestinationError> {
-        let mut values = vec![];
-        if self.prepend_zero() {
+        let mut values = self.values_ascending();
+        if self.prepend_zero() || !marginal {
             values.push(0);
         }
-        values.extend(self.values_ascending());
+        values.sort();
+        values.dedup();
         if values.len() < 2 {
             return Err(DestinationError::InvalidBinConfig {
                 reason: format!(

--- a/rust/bambam-core/src/model/destination/bin.rs
+++ b/rust/bambam-core/src/model/destination/bin.rs
@@ -449,10 +449,10 @@ mod tests {
             prepend_zero: false,
         };
         let bins = config.build_bins(false).unwrap();
-        for (bin, expected_max) in bins.into_iter().zip([20.0, 30.0]) {
+        for (bin, expected_max) in bins.into_iter().zip([10.0, 20.0, 30.0]) {
             match bin {
                 BinInterval::Time { min, max, .. } => {
-                    assert_eq!(min, Time::new::<minute>(10.0));
+                    assert_eq!(min, Time::new::<minute>(0.0));
                     assert_eq!(max, Time::new::<minute>(expected_max));
                 }
                 _ => panic!("unexpected bin type"),

--- a/rust/bambam-core/src/model/destination/bin.rs
+++ b/rust/bambam-core/src/model/destination/bin.rs
@@ -420,6 +420,46 @@ mod tests {
         }
     }
 
+    #[test]
+    fn build_bins_not_marginal_prepends_zero_when_enabled() {
+        let config = BinningConfig::Time {
+            feature: "travel_time".to_string(),
+            values: vec![10, 20, 30],
+            unit: TimeUnit::Minutes,
+            prepend_zero: true,
+        };
+        let bins = config.build_bins(false).unwrap();
+        for (bin, expected_max) in bins.into_iter().zip([10.0, 20.0, 30.0]) {
+            match bin {
+                BinInterval::Time { min, max, .. } => {
+                    assert_eq!(min, Time::new::<minute>(0.0));
+                    assert_eq!(max, Time::new::<minute>(expected_max));
+                }
+                _ => panic!("unexpected bin type"),
+            }
+        }
+    }
+
+    #[test]
+    fn build_bins_not_marginal_without_zero_and_no_prepend_uses_first_value() {
+        let config = BinningConfig::Time {
+            feature: "travel_time".to_string(),
+            values: vec![10, 20, 30],
+            unit: TimeUnit::Minutes,
+            prepend_zero: false,
+        };
+        let bins = config.build_bins(false).unwrap();
+        for (bin, expected_max) in bins.into_iter().zip([20.0, 30.0]) {
+            match bin {
+                BinInterval::Time { min, max, .. } => {
+                    assert_eq!(min, Time::new::<minute>(10.0));
+                    assert_eq!(max, Time::new::<minute>(expected_max));
+                }
+                _ => panic!("unexpected bin type"),
+            }
+        }
+    }
+
     /// Each bin key matches the upper bound of that bin.
     #[test]
     fn bin_keys_match_upper_bounds() {

--- a/rust/bambam-core/src/model/destination/bin.rs
+++ b/rust/bambam-core/src/model/destination/bin.rs
@@ -4,6 +4,7 @@ use routee_compass_core::model::{
     unit::{DistanceUnit, EnergyUnit, TimeUnit},
 };
 use serde::{Deserialize, Serialize};
+use uom::ConstZero;
 
 use crate::model::destination::DestinationError;
 
@@ -130,8 +131,17 @@ impl BinningConfig {
 
     /// create the collection of bins from this configuration. each of these bins will capture
     /// a subset of the destinations.
-    pub fn build_bins(&self) -> Result<Vec<BinInterval>, DestinationError> {
-        let mut values = self.values_ascending();
+    ///
+    /// # Arguments
+    ///
+    /// * `marginal` - if true, each bin interval will be bounded by two consecutive values in the
+    /// binning config. if false, each bin will start with zero.
+    pub fn build_bins(&self, marginal: bool) -> Result<Vec<BinInterval>, DestinationError> {
+        let mut values = vec![];
+        if self.prepend_zero() {
+            values.push(0);
+        }
+        values.extend(self.values_ascending().into_iter());
         if values.len() < 2 {
             return Err(DestinationError::InvalidBinConfig {
                 reason: format!(
@@ -140,9 +150,6 @@ impl BinningConfig {
                 ),
             });
         }
-        if self.prepend_zero() {
-            values.insert(0, 0);
-        }
 
         let bins = match self {
             BinningConfig::Distance { feature, unit, .. } => values
@@ -150,7 +157,11 @@ impl BinningConfig {
                 .tuple_windows()
                 .map(|(min, max)| BinInterval::Distance {
                     feature: feature.to_string(),
-                    min: unit.to_uom(*min as f64),
+                    min: if marginal {
+                        unit.to_uom(*min as f64)
+                    } else {
+                        uom::si::f64::Length::ZERO
+                    },
                     max: unit.to_uom(*max as f64),
                     unit: *unit,
                 })
@@ -160,7 +171,11 @@ impl BinningConfig {
                 .tuple_windows()
                 .map(|(min, max)| BinInterval::Time {
                     feature: feature.to_string(),
-                    min: unit.to_uom(*min as f64),
+                    min: if marginal {
+                        unit.to_uom(*min as f64)
+                    } else {
+                        uom::si::f64::Time::ZERO
+                    },
                     max: unit.to_uom(*max as f64),
                     unit: *unit,
                 })
@@ -170,7 +185,11 @@ impl BinningConfig {
                 .tuple_windows()
                 .map(|(min, max)| BinInterval::Energy {
                     feature: feature.to_string(),
-                    min: unit.to_uom(*min as f64),
+                    min: if marginal {
+                        unit.to_uom(*min as f64)
+                    } else {
+                        uom::si::f64::Energy::ZERO
+                    },
                     max: unit.to_uom(*max as f64),
                     unit: *unit,
                 })
@@ -184,7 +203,7 @@ impl BinningConfig {
                     .iter()
                     .tuple_windows()
                     .map(|(min, max)| BinInterval::CustomRange {
-                        min: *min as f64,
+                        min: if marginal { *min as f64 } else { 0.0 },
                         max: *max as f64,
                         feature: feature.to_string(),
                         unit: unit.clone(),
@@ -361,8 +380,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::BinningConfig;
+    use super::{BinInterval, BinningConfig};
     use routee_compass_core::model::unit::TimeUnit;
+    use uom::si::{f64::Time, time::minute};
 
     /// BinRangeConfig with N values produces N-1 bins (sliding window).
     #[test]
@@ -373,8 +393,30 @@ mod tests {
             unit: TimeUnit::Minutes,
             prepend_zero: false,
         };
-        let bins = config.build_bins().unwrap();
+        let bins = config.build_bins(true).unwrap();
         assert_eq!(bins.len(), 3);
+    }
+
+    /// marginal = false
+    #[test]
+    fn build_bins_not_marginal() {
+        let feature = "travel_time".to_string();
+        let config = BinningConfig::Time {
+            feature: feature.clone(),
+            values: vec![0, 10, 20, 30],
+            unit: TimeUnit::Minutes,
+            prepend_zero: false,
+        };
+        let bins = config.build_bins(false).unwrap();
+        for (bin, expected_max) in bins.into_iter().zip([10.0, 20.0, 30.0]) {
+            match bin {
+                BinInterval::Time { min, max, .. } => {
+                    assert_eq!(min, Time::new::<minute>(0.0));
+                    assert_eq!(max, Time::new::<minute>(expected_max));
+                }
+                _ => panic!("unexpected bin type"),
+            }
+        }
     }
 
     /// Each bin key matches the upper bound of that bin.
@@ -386,7 +428,7 @@ mod tests {
             unit: TimeUnit::Minutes,
             prepend_zero: false,
         };
-        let bins = config.build_bins().unwrap();
+        let bins = config.build_bins(true).unwrap();
         let keys: Vec<String> = bins.iter().map(|b| b.bin_key()).collect();
         assert_eq!(keys, vec!["10", "20", "30"]);
     }
@@ -399,7 +441,7 @@ mod tests {
             unit: TimeUnit::Minutes,
             prepend_zero: true,
         };
-        assert!(config.build_bins().is_err());
+        assert!(config.build_bins(true).is_err());
     }
 
     #[test]
@@ -410,7 +452,7 @@ mod tests {
             unit: TimeUnit::Minutes,
             prepend_zero: true,
         };
-        assert!(config.build_bins().is_err());
+        assert!(config.build_bins(true).is_err());
     }
 
     #[test]
@@ -421,7 +463,7 @@ mod tests {
             unit: TimeUnit::Minutes,
             prepend_zero: false,
         };
-        let bins = config.build_bins().unwrap();
+        let bins = config.build_bins(true).unwrap();
         let keys: Vec<String> = bins.iter().map(|b| b.bin_key()).collect();
         assert_eq!(keys, vec!["10", "20", "30"]);
     }
@@ -434,7 +476,7 @@ mod tests {
             unit: TimeUnit::Minutes,
             prepend_zero: false,
         };
-        let bins = config.build_bins().unwrap();
+        let bins = config.build_bins(true).unwrap();
         assert_eq!(bins.len(), 2); // [0,10), [10,20)
     }
 }

--- a/rust/bambam-core/src/model/destination/bin.rs
+++ b/rust/bambam-core/src/model/destination/bin.rs
@@ -439,7 +439,7 @@ mod tests {
             feature: "travel_time".to_string(),
             values: vec![10],
             unit: TimeUnit::Minutes,
-            prepend_zero: true,
+            prepend_zero: false,
         };
         assert!(config.build_bins(true).is_err());
     }

--- a/rust/bambam-omf/src/collection/filter/travel_mode_filter.rs
+++ b/rust/bambam-omf/src/collection/filter/travel_mode_filter.rs
@@ -124,28 +124,25 @@ impl ModeAccessAccumulator {
         use SegmentHeading as SH;
         match (&r.access_type, has_mode, heading, mods) {
             // 1. Blanket Denial
-            (SAT::Denied, None, None, None) => {
-                if self.state == ModeAccessState::DefaultAllowed {
+            (SAT::Denied, None, None, None)
+                if self.state == ModeAccessState::DefaultAllowed => {
                     self.state = ModeAccessState::BlanketDenied;
                 }
-            }
             // 2. Specific Denial overrides everything
             (SAT::Denied, Some(true), None | Some(SH::Forward), _) => {
                 self.state = ModeAccessState::SpecificallyDenied;
             }
             // 3. Exception Allowed (if we were blanket denied, or just explicitly allowed)
-            (SAT::Allowed | SAT::Designated, Some(true), None | Some(SH::Forward), None) => {
-                if self.state != ModeAccessState::SpecificallyDenied {
+            (SAT::Allowed | SAT::Designated, Some(true), None | Some(SH::Forward), None)
+                if self.state != ModeAccessState::SpecificallyDenied => {
                     self.state = ModeAccessState::AllowedException;
                 }
-            }
             // 4. Conditional Exception (e.g. Employee only) -> We don't support special conditions, so deny access
-            (SAT::Allowed | SAT::Designated, Some(true), None | Some(SH::Forward), Some(true)) => {
+            (SAT::Allowed | SAT::Designated, Some(true), None | Some(SH::Forward), Some(true))
                 // If we relied on this conditional to be allowed, we must explicitly deny
-                if self.state != ModeAccessState::SpecificallyDenied {
+                if self.state != ModeAccessState::SpecificallyDenied => {
                     self.state = ModeAccessState::SpecificallyDenied;
                 }
-            }
             _ => {}
         }
     }

--- a/rust/bambam/src/model/output_plugin/isochrone/isochrone_output_plugin.rs
+++ b/rust/bambam/src/model/output_plugin/isochrone/isochrone_output_plugin.rs
@@ -58,7 +58,7 @@ pub fn run_isochrone(
 
     let mut agg = row.aggregate()?;
     let bins = bin_config
-        .build_bins()
+        .build_bins(false)
         .map_err(|e| OutputPluginError::OutputPluginFailed(e.to_string()))?;
     for bin in bins.into_iter() {
         let bin_key = bin.bin_key();

--- a/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
@@ -142,7 +142,7 @@ fn process_aggregate_opportunities(
 
     let mut agg = row.aggregate()?;
     let bins = bin_config
-        .build_bins()
+        .build_bins(false)
         .map_err(|e| OutputPluginError::OutputPluginFailed(e.to_string()))?;
     for bin in bins.into_iter() {
         let start_time = Instant::now();


### PR DESCRIPTION
this PR modifies opportunity binning so that the entire collection of opportunities are counted within a bin. previously, we "clipped" the counting to the range [t-10, t), but this creates complications when added to the MEP calculation, so now we collect counts within [0, t).