### PR TITLE
Release/0.3.2

### DIFF
--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -3,6 +3,7 @@ name: Publish - crates.io
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -29,29 +30,12 @@ jobs:
       - name: Run unit tests
         run: cargo test --workspace --manifest-path=rust/Cargo.toml -- --skip test_e2e
 
-      - name: Publish bambam-core
-        run: cargo publish -p bambam-core --manifest-path=rust/Cargo.toml
-      
-      - name: Publish bambam-osm
-        run: cargo publish -p bambam-osm --manifest-path=rust/Cargo.toml
+      - name: Validate publish flow (dry-run)
+        run: sh script/publish_crates.sh --dry-run --manifest-path rust/Cargo.toml
 
-      - name: Publish bambam-gtfs
-        run: cargo publish -p bambam-gtfs --manifest-path=rust/Cargo.toml
-
-      - name: Publish bambam-gbfs
-        run: cargo publish -p bambam-gbfs --manifest-path=rust/Cargo.toml
-
-      - name: Publish bambam-omf
-        run: cargo publish -p bambam-omf --manifest-path=rust/Cargo.toml
-
-      - name: Publish bambam-gtfs-flex
-        run: cargo publish -p bambam-gtfs-flex --manifest-path=rust/Cargo.toml
-
-      - name: Publish bambam
-
-        run: | 
-          sleep 2 # ensure all bambam-* crates are avaiable on crates.io
-          cargo publish -p bambam --manifest-path=rust/Cargo.toml
+      - name: Publish crates
+        if: github.event_name == 'release'
+        run: sh script/publish_crates.sh --manifest-path rust/Cargo.toml
 
 #       - name: Publish bambam-py
 #         run: cargo publish -p bambam-py --manifest-path=rust/Cargo.toml

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,7 +41,6 @@ geo-buffer = "0.2.0"
 geo-traits = "0.3.0"
 geo-types = "=0.7.19"
 geozero = { version = "0.14.0", features = ["with-geo", "with-wkb", "with-wkt", "with-geojson"] }
-gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { version = "0.9.4", features = ["serde", "geo"] }
 hex = "0.4.3"
 humantime = "2.3.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "bambam-gtfs-flex",
     "bambam-omf",
     "bambam-osm",
-    # "bambam-py",
+    "bambam-py",
 ]
 
 [workspace.package]
@@ -62,11 +62,11 @@ rand = "0.10.0"
 rayon = "1.10.0"
 regex = { version = "1.11.1" }
 reqwest = { version = "0.12.12", features = ["blocking"] }
-routee-compass = { version = "0.19.4", default-features = false }
-routee-compass-core = { version = "0.19.4" }
-routee-compass-macros = { version = "0.19.4" }
-# routee-compass-powertrain = { version = "0.19.4" }
-routee-compass-py = { version = "0.19.4", default-features = false }
+routee-compass = { version = "0.19.5", default-features = false }
+routee-compass-core = { version = "0.19.5" }
+routee-compass-macros = { version = "0.19.5" }
+# routee-compass-powertrain = { version = "0.19.5" }
+routee-compass-py = { version = "0.19.5", default-features = false }
 rstar = { version = "0.12.2" }
 sanitize-filename = "0.6.0"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "bambam-gtfs-flex",
     "bambam-omf",
     "bambam-osm",
-    "bambam-py",
+    # "bambam-py",
 ]
 
 [workspace.package]
@@ -41,6 +41,7 @@ geo-buffer = "0.2.0"
 geo-traits = "0.3.0"
 geo-types = "=0.7.19"
 geozero = { version = "0.14.0", features = ["with-geo", "with-wkb", "with-wkt", "with-geojson"] }
+gtfs-structures = { git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { version = "0.9.4", features = ["serde", "geo"] }
 hex = "0.4.3"
 humantime = "2.3.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,7 +41,7 @@ geo-buffer = "0.2.0"
 geo-traits = "0.3.0"
 geo-types = "=0.7.19"
 geozero = { version = "0.14.0", features = ["with-geo", "with-wkb", "with-wkt", "with-geojson"] }
-gtfs-structures = { git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
+gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { version = "0.9.4", features = ["serde", "geo"] }
 hex = "0.4.3"
 humantime = "2.3.0"

--- a/rust/bambam-gtfs-flex/Cargo.toml
+++ b/rust/bambam-gtfs-flex/Cargo.toml
@@ -16,7 +16,7 @@ flate2 = { workspace = true }
 geo = { workspace = true }
 geo-types = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { workspace = true }
+gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 kdam = { workspace = true }
 log = { workspace = true }
 ordered-float = { workspace = true }

--- a/rust/bambam-gtfs-flex/Cargo.toml
+++ b/rust/bambam-gtfs-flex/Cargo.toml
@@ -16,7 +16,7 @@ flate2 = { workspace = true }
 geo = { workspace = true }
 geo-types = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
+gtfs-structures = { git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 kdam = { workspace = true }
 log = { workspace = true }
 ordered-float = { workspace = true }

--- a/rust/bambam-gtfs/Cargo.toml
+++ b/rust/bambam-gtfs/Cargo.toml
@@ -22,13 +22,13 @@ env_logger = { workspace = true }
 flate2 = { workspace = true }
 geo = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
+gtfs-structures = { git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { workspace = true }
 itertools = { workspace = true }
 kdam = { workspace = true }
 log = { workspace = true }
 rayon = { workspace = true }
-routee-compass = { workspace = true }
+routee-compass = { workspace = true, default-features = false }
 routee-compass-core = { workspace = true }
 rstar = { workspace = true }
 serde = { workspace = true }

--- a/rust/bambam-gtfs/Cargo.toml
+++ b/rust/bambam-gtfs/Cargo.toml
@@ -22,7 +22,7 @@ env_logger = { workspace = true }
 flate2 = { workspace = true }
 geo = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { workspace = true }
+gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { workspace = true }
 itertools = { workspace = true }
 kdam = { workspace = true }

--- a/rust/bambam-omf/Cargo.toml
+++ b/rust/bambam-omf/Cargo.toml
@@ -38,7 +38,7 @@ ordered-float = { workspace = true }
 parquet = { workspace = true }
 rayon = { workspace = true }
 reqwest = { workspace = true }
-routee-compass = { workspace = true }
+routee-compass = { workspace = true, default-features = false }
 routee-compass-core = { workspace = true }
 # routee-compass-powertrain = { workspace = true }
 serde = { workspace = true }

--- a/rust/bambam-osm/Cargo.toml
+++ b/rust/bambam-osm/Cargo.toml
@@ -24,7 +24,7 @@ flate2 = { workspace = true }
 geo = { workspace = true }
 geo-buffer = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
+gtfs-structures = { version = "=0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { workspace = true }
 itertools = { workspace = true }
 kdam = { workspace = true }

--- a/rust/bambam-osm/Cargo.toml
+++ b/rust/bambam-osm/Cargo.toml
@@ -24,7 +24,7 @@ flate2 = { workspace = true }
 geo = { workspace = true }
 geo-buffer = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { version = "=0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
+gtfs-structures = { git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { workspace = true }
 itertools = { workspace = true }
 kdam = { workspace = true }
@@ -34,7 +34,7 @@ osmio = { workspace = true }
 osmpbf = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
-routee-compass = { workspace = true }
+routee-compass = { workspace = true, default-features = false }
 routee-compass-core = { workspace = true }
 # routee-compass-powertrain = { workspace = true }
 rstar = { workspace = true }

--- a/rust/bambam-osm/Cargo.toml
+++ b/rust/bambam-osm/Cargo.toml
@@ -24,7 +24,7 @@ flate2 = { workspace = true }
 geo = { workspace = true }
 geo-buffer = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { workspace = true }
+gtfs-structures = { version = "0.46.1", git = "https://github.com/robfitzgerald/gtfs-structure", branch = "rjf/135-gtfs-flex", features = ["gtfs-flex"] }
 h3o = { workspace = true }
 itertools = { workspace = true }
 kdam = { workspace = true }

--- a/rust/bambam-py/Cargo.toml
+++ b/rust/bambam-py/Cargo.toml
@@ -15,10 +15,10 @@ inventory = { workspace = true }
 itertools = { workspace = true }
 
 pyo3 = { version = "0.28.0", features = ["extension-module", "serde"] }
-routee-compass = { workspace = true }
+routee-compass = { workspace = true, default-features = false }
 routee-compass-core = { workspace = true }
 routee-compass-macros = { workspace = true }
-routee-compass-py = { workspace = true }
+routee-compass-py = { workspace = true, default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/bambam-py/Cargo.toml
+++ b/rust/bambam-py/Cargo.toml
@@ -14,7 +14,7 @@ inventory = { workspace = true }
 
 itertools = { workspace = true }
 
-pyo3 = { version = "0.28.0", features = ["extension-module", "serde"] }
+pyo3 = { version = "0.29.0", features = ["extension-module", "serde"] }
 routee-compass = { workspace = true, default-features = false }
 routee-compass-core = { workspace = true }
 routee-compass-macros = { workspace = true }

--- a/rust/bambam/Cargo.toml
+++ b/rust/bambam/Cargo.toml
@@ -33,7 +33,7 @@ geo = { workspace = true }
 geo-traits = { workspace = true }
 geo-types = { workspace = true }
 geozero = { workspace = true }
-gtfs-structures = { workspace = true }
+# gtfs-structures = { workspace = true }
 h3o = { workspace = true }
 hex = { workspace = true }
 inventory = { workspace = true }

--- a/rust/bambam/Cargo.toml
+++ b/rust/bambam/Cargo.toml
@@ -44,7 +44,7 @@ log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
-routee-compass = { workspace = true }
+routee-compass = { workspace = true, default-features = false }
 routee-compass-core = { workspace = true }
 # routee-compass-powertrain = { workspace = true }
 rstar = { workspace = true }

--- a/script/publish_crates.sh
+++ b/script/publish_crates.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+set -eu
+
+MANIFEST_PATH="rust/Cargo.toml"
+DRY_RUN=0
+CRATES_CSV=""
+DEFAULT_CRATES="bambam-core bambam-osm bambam-gtfs bambam-gbfs bambam-omf bambam-gtfs-flex bambam"
+
+usage() {
+  cat <<'EOF'
+Usage: script/publish_crates.sh [--dry-run] [--manifest-path <path>] [--crates <comma-delimited-names>]
+
+Publishes bambam crates to crates.io in dependency order.
+Use --dry-run to validate each publish command without uploading.
+Use --crates to run a comma-delimited subset (for reruns after partial failure).
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --manifest-path)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "missing value for --manifest-path" >&2
+        usage
+        exit 2
+      fi
+      MANIFEST_PATH="$1"
+      ;;
+    --crates)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "missing value for --crates" >&2
+        usage
+        exit 2
+      fi
+      CRATES_CSV="$1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$CRATES_CSV" ]; then
+  # Normalize comma-delimited input by removing whitespace.
+  CRATES_CSV="$(printf '%s' "$CRATES_CSV" | tr -d '[:space:]')"
+  if [ -z "$CRATES_CSV" ]; then
+    echo "--crates cannot be empty" >&2
+    exit 2
+  fi
+  CRATES="$(printf '%s' "$CRATES_CSV" | tr ',' ' ')"
+else
+  CRATES="$DEFAULT_CRATES"
+fi
+
+run_publish() {
+  crate="$1"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "dry-run publish for ${crate}"
+    # --no-verify avoids false failures when sibling crate versions are not yet on crates.io.
+    cargo publish -p "$crate" --manifest-path="$MANIFEST_PATH" --dry-run --no-verify
+  else
+    echo "publishing ${crate}"
+    cargo publish -p "$crate" --manifest-path="$MANIFEST_PATH"
+  fi
+}
+
+for crate in $CRATES; do
+  if [ "$DRY_RUN" -eq 0 ] && [ "$crate" = "bambam" ]; then
+    # crates.io indexing can lag briefly; wait before publishing the umbrella crate.
+    sleep 2
+  fi
+  run_publish "$crate"
+done


### PR DESCRIPTION
this branch contains an attempt to publish a v0.3.2 of bambam. however, two issues prevent the release:
  1. crates.io will not accept our dependency on a custom fork of gtfs-structures
  2. routee-compass-py broke it's behavior for default-features = false compilation which we rely on

this PR rolls in the 0.3.2 release changes into main.