### PR TITLE
Rjf/omf csv mapping source

### DIFF
--- a/rust/bambam/src/model/output_plugin/opportunity/opportunity_source.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/opportunity_source.rs
@@ -1,4 +1,6 @@
-use crate::model::output_plugin::opportunity::OpportunityDataset;
+use crate::model::output_plugin::opportunity::{
+    source::OverturePlacesMappingConfig, OpportunityDataset,
+};
 
 use super::{
     source::lodes::lodes_ops,
@@ -39,7 +41,7 @@ pub enum OpportunitySource {
     OvertureMapsPlaces {
         collector_config: OvertureMapsCollectorConfig,
         bbox_boundary: Bbox,
-        places_activity_mapping: HashMap<String, Vec<String>>,
+        places_activity_mapping: OverturePlacesMappingConfig,
         buildings_activity_mapping: Option<HashMap<String, Vec<String>>>,
         #[serde(default)]
         release_version: ReleaseVersion,
@@ -70,6 +72,8 @@ impl OpportunitySource {
                 buildings_activity_mapping,
                 release_version,
             } => {
+                let places_mapping = places_activity_mapping.build()?;
+
                 // Instantiate Collection Model Object which re-structures activity mapping
                 // information into a fully functional collection pipeline. This step allows
                 // to reduce repetition in the configuration file by making some assumptions
@@ -78,7 +82,7 @@ impl OpportunitySource {
                     *collector_config,
                     release_version.clone(),
                     *bbox_boundary,
-                    places_activity_mapping.clone(),
+                    places_mapping,
                     buildings_activity_mapping.clone(),
                 )
                 .map_err(|e| format!("Error creating Overture OpportunityCollectionModel: {e}"))?;

--- a/rust/bambam/src/model/output_plugin/opportunity/source/mod.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/mod.rs
@@ -1,2 +1,5 @@
 pub mod lodes;
 pub mod overture_opportunity_collection_model;
+mod overture_places_mapping;
+
+pub use overture_places_mapping::OverturePlacesMappingConfig;

--- a/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
@@ -6,6 +6,12 @@ use serde::{Deserialize, Serialize};
 
 pub type PlacesMapping = HashMap<String, Vec<String>>;
 
+/// sources a mapping from OvertureMaps Places categories into MEP categories.
+///
+/// # Serde
+///
+/// untagged deserialization. attempts to first deserialize directly as a HashMap.
+/// if that fails, attempts to read as a FromCsv object.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum OverturePlacesMappingConfig {

--- a/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
@@ -1,0 +1,94 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use csv::StringRecord;
+use routee_compass_core::util::fs::read_utils;
+use serde::{Deserialize, Serialize};
+
+pub type PlacesMapping = HashMap<String, Vec<String>>;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum OverturePlacesMappingConfig {
+    FromConfig(PlacesMapping),
+    FromCsv {
+        places_mapping_input_file: String,
+        places_category_column: String,
+        mep_category_column: String,
+        mep_category_separator: String,
+    },
+}
+
+impl OverturePlacesMappingConfig {
+    pub fn build(&self) -> Result<PlacesMapping, String> {
+        match self {
+            OverturePlacesMappingConfig::FromConfig(hash_map) => Ok(hash_map.clone()),
+            OverturePlacesMappingConfig::FromCsv {
+                places_mapping_input_file,
+                places_category_column,
+                mep_category_column,
+                mep_category_separator,
+            } => {
+                let mut reader = csv::ReaderBuilder::new()
+                    .has_headers(true)
+                    .from_path(places_mapping_input_file)
+                    .map_err(|e| {
+                        format!(
+                            "failure reading mep mapping csv at {places_mapping_input_file}: {e}"
+                        )
+                    })?;
+                let header_records = reader
+                    .headers()
+                    .map_err(|e| format!("mep mapping csv should have headers. {e}"))?;
+                let header: HashMap<String, usize> = header_records
+                    .iter()
+                    .enumerate()
+                    .map(|(col_idx, name)| (name.to_string(), col_idx))
+                    .collect();
+
+                let mut result = HashMap::new();
+                for (row_idx, row_result) in reader.into_records().enumerate() {
+                    let (omf_label, mep_labels) = process_row(
+                        row_idx,
+                        row_result,
+                        &header,
+                        places_category_column,
+                        mep_category_column,
+                        mep_category_separator,
+                    )?;
+                    let _ = result.insert(omf_label, mep_labels);
+                }
+                Ok(result)
+            }
+        }
+    }
+}
+
+/// helper function to process a row of the MEP mapping CSV file.
+fn process_row(
+    row_idx: usize,
+    row_result: Result<StringRecord, csv::Error>,
+    header: &HashMap<String, usize>,
+    places_category_column: &str,
+    mep_category_column: &str,
+    mep_category_separator: &str,
+) -> Result<(String, Vec<String>), String> {
+    let row = row_result
+        .map_err(|e| format!("failure getting row {row_idx} from mep mapping csv: {e}"))?;
+    let omf_label_col_idx = header.get(places_category_column).ok_or_else(|| {
+        format!("mep mapping csv missing expected {places_category_column} column")
+    })?;
+    let mep_label_col_idx = header
+        .get(mep_category_column)
+        .ok_or_else(|| format!("mep mapping csv missing expected {mep_category_column} column"))?;
+
+    let omf_label = row.get(*omf_label_col_idx)
+        .ok_or_else(|| format!("mep mapping csv row {row_idx} missing expected {places_category_column} column index {omf_label_col_idx}"))?
+        .to_string();
+    let mep_labels: Vec<String> = row.get(*mep_label_col_idx)
+        .ok_or_else(|| format!("mep mapping csv row {row_idx} missing expected {mep_category_column} column index {mep_label_col_idx}"))?
+        .split(mep_category_separator)
+        .map(String::from)
+        .collect();
+
+    Ok((omf_label, mep_labels))
+}


### PR DESCRIPTION
this PR introduces an alternative means to load an OvertureMaps Places mapping. these mappings can be quite long - there are over 2000 OvertureMaps categories total - and so expressing that directly within a bambam config file is noisy. this PR allows the user to alternatively define a CSV source for category mapping:

```toml
[plugin.output_plugins.model.models.opportunity_source.places_activity_mapping]
places_mapping_input_file = "mapping.csv"
places_category_column = "omf_label"
mep_category_column = "mep_labels"
mep_category_separator = "-"  # sep to use when more than one MEP label is produced
```

### testing

1. unpack and copy these files into the base of the bambam repo:

[omf-csv-test-assets.zip](https://github.com/user-attachments/files/29817765/omf-csv-test-assets.zip)

```
overture-to-mep.csv
test_denver_omf.toml
```

2. run bambam:
```sh
% cargo build -r --manifest-path rust/Cargo.toml
% RUST_LOG=info ./rust/target/release/bambam -c test_denver_omf.toml -q query/denver_extent.json
```

3. a JSON and CSV output should appear with no errors logged to console or into the file contents, and the opportunities counted for each grid cell/mode/timebin come from OvertureMaps categories mapped to MEP categories as defined in teh overture-to-mep.csv file instance.