### PR TITLE
Rjf/gtfs final fixes

### DIFF
--- a/rust/bambam-core/src/model/bambam_typed.rs
+++ b/rust/bambam-core/src/model/bambam_typed.rs
@@ -37,13 +37,14 @@
 
 use std::collections::HashMap;
 
+use itertools::Itertools;
 use routee_compass::plugin::output::OutputPluginError;
 use routee_compass_core::model::cost::TraversalCost;
 use serde_json::{json, Value};
 
 use crate::model::{
     bambam_field,
-    destination::{BinningConfig, DestinationPredicate},
+    destination::{BinningConfig, DestinationFilter, DestinationPredicate},
     output_plugin::{
         isochrone::{GeometryModelConfig, IsochroneAlgorithm, IsochroneOutputFormat},
         opportunity::{OpportunityFormat, OpportunityOrientation},
@@ -116,6 +117,26 @@ impl<'a> BambamOutputRow<'a> {
     ) -> Result<(), OutputPluginError> {
         set_field(self.0, bambam_field::OPPORTUNITY_TOTALS, totals)
     }
+
+    /// grabs any destination filters from both two places:
+    ///  - info section (set via the config file)
+    ///  - request section (set via the search query)
+    pub fn get_destination_filter(&self) -> Result<Option<DestinationFilter>, OutputPluginError> {
+        let info = self.info_ref()?;
+        let info_filter = info.get_config_destination_predicates()?;
+        let req = self.request()?;
+        let req_filter: Option<Vec<DestinationPredicate>> =
+            get_field_opt(req.0, bambam_field::DESTINATION_FILTER)?;
+        match (info_filter, req_filter) {
+            (None, None) => Ok(None),
+            (None, Some(preds)) => Ok(Some(DestinationFilter(preds))),
+            (Some(preds), None) => Ok(Some(DestinationFilter(preds))),
+            (Some(preds_config), Some(preds_query)) => {
+                let preds = preds_config.into_iter().chain(preds_query).collect_vec();
+                Ok(Some(DestinationFilter(preds)))
+            }
+        }
+    }
 }
 
 // ─── request section ──────────────────────────────────────────────────────────
@@ -152,7 +173,8 @@ impl<'a> InfoSectionRef<'a> {
         get_field_opt(self.0, bambam_field::BIN_RANGE)
     }
 
-    pub fn get_destination_filter(
+    /// gets any destination predicates set on the BAMBAM config.
+    pub fn get_config_destination_predicates(
         &self,
     ) -> Result<Option<Vec<DestinationPredicate>>, OutputPluginError> {
         get_field_opt(self.0, bambam_field::DESTINATION_FILTER)
@@ -541,7 +563,7 @@ mod tests {
         let info = row.info_ref().unwrap();
         assert!(info.get_activity_types().unwrap().is_none());
         assert!(info.get_bin_range().unwrap().is_none());
-        assert!(info.get_destination_filter().unwrap().is_none());
+        assert!(info.get_config_destination_predicates().unwrap().is_none());
         assert!(info.get_opportunity_format().unwrap().is_none());
         assert!(info.get_opportunity_orientation().unwrap().is_none());
         assert!(info.get_geometry_model().unwrap().is_none());

--- a/rust/bambam-core/src/model/destination/filter.rs
+++ b/rust/bambam-core/src/model/destination/filter.rs
@@ -10,6 +10,7 @@ pub struct DestinationFilter(pub Vec<DestinationPredicate>);
 
 /// additional modifiers to apply when collecting destinations for a bin.
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum DestinationPredicate {
     /// only accept destinations where the provided feature, a boolean value,
     /// is true (or, if negate == true, where the feature is false).
@@ -17,7 +18,7 @@ pub enum DestinationPredicate {
         /// state variable feature to match
         feature: String,
         /// if true, invert the value stored at the feature    
-        negate: bool,
+        negate: Option<bool>,
     },
 }
 
@@ -43,7 +44,7 @@ impl std::fmt::Display for DestinationPredicate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             DestinationPredicate::Boolean { feature, negate } => {
-                if !negate {
+                if !negate.unwrap_or_default() {
                     format!("{feature}=true")
                 } else {
                     format!("{feature}=false")
@@ -68,7 +69,7 @@ impl DestinationPredicate {
                         error: e,
                     }
                 })?;
-                Ok(variable != *negate) // if negate=false, variable should be true, and vice versa
+                Ok(variable != negate.unwrap_or_default()) // if negate=false, variable should be true, and vice versa
             }
         }
     }
@@ -105,7 +106,7 @@ mod tests {
         // When feature is true and negate is false, should return true
         let predicate = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: false,
+            negate: Some(false),
         };
 
         let (state_model, state) = mock(&[("is_available", true)]);
@@ -120,7 +121,7 @@ mod tests {
         // When feature is true and negate is true, should return false
         let predicate = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: true,
+            negate: Some(true),
         };
 
         let (state_model, state) = mock(&[("is_available", true)]);
@@ -135,7 +136,7 @@ mod tests {
         // When feature is false and negate is false, should return false
         let predicate = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: false,
+            negate: Some(false),
         };
 
         let (state_model, state) = mock(&[("is_available", false)]);
@@ -150,7 +151,7 @@ mod tests {
         // When feature is false and negate is true, should return true
         let predicate = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: true,
+            negate: Some(true),
         };
 
         let (state_model, state) = mock(&[("is_available", false)]);
@@ -165,7 +166,7 @@ mod tests {
         // Filter should only check the specified feature and ignore other variables
         let predicate = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: false,
+            negate: Some(false),
         };
         let filter = DestinationFilter(vec![predicate]);
 
@@ -181,11 +182,11 @@ mod tests {
         // Multiple predicates in a filter should all pass for the filter to return true
         let pred1 = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: false,
+            negate: Some(false),
         };
         let pred2 = DestinationPredicate::Boolean {
             feature: "is_active".to_string(),
-            negate: false,
+            negate: Some(false),
         };
         let filter = DestinationFilter(vec![pred1, pred2]);
 
@@ -201,11 +202,11 @@ mod tests {
         // If one predicate fails, the entire filter should fail
         let pred1 = DestinationPredicate::Boolean {
             feature: "is_available".to_string(),
-            negate: false,
+            negate: Some(false),
         };
         let pred2 = DestinationPredicate::Boolean {
             feature: "is_active".to_string(),
-            negate: false,
+            negate: Some(false),
         };
         let filter = DestinationFilter(vec![pred1, pred2]);
 

--- a/rust/bambam-core/src/model/state/multimodal_state_ops.rs
+++ b/rust/bambam-core/src/model/state/multimodal_state_ops.rs
@@ -97,10 +97,14 @@ pub fn contains_leg(
     state: &[StateVariable],
     leg_idx: LegIdx,
     state_model: &StateModel,
+    max_trip_legs: NonZeroU64,
 ) -> Result<bool, StateModelError> {
+    if leg_idx >= max_trip_legs.get() {
+        return Ok(false);
+    }
     let name = fieldname::leg_mode_fieldname(leg_idx);
     let label = state_model.get_custom_i64(state, &name)?;
-    Ok(label >= 0)
+    Ok(label > -1)
 }
 
 /// get the travel mode for a leg.
@@ -110,7 +114,10 @@ pub fn get_leg_mode_label(
     state_model: &StateModel,
     max_trip_legs: NonZeroU64,
 ) -> Result<Option<i64>, StateModelError> {
-    validate_leg_idx(leg_idx, max_trip_legs)?;
+    validate_leg_idx(leg_idx, max_trip_legs).map_err(|e| {
+        let msg = format!("while getting leg mode label, found requested leg idx is invalid: {e}");
+        StateModelError::RuntimeError(msg)
+    })?;
     let name = fieldname::leg_mode_fieldname(leg_idx);
     let label = state_model.get_custom_i64(state, &name)?;
     if label < 0 {
@@ -129,7 +136,11 @@ pub fn get_existing_leg_mode<'a>(
     max_trip_legs: NonZeroU64,
     mode_to_state: &'a CategoricalStateMapping,
 ) -> Result<&'a str, StateModelError> {
-    let label_opt = get_leg_mode_label(state, leg_idx, state_model, max_trip_legs)?;
+    let label_opt =
+        get_leg_mode_label(state, leg_idx, state_model, max_trip_legs).map_err(|e| {
+            let msg = format!("while getting existing leg mode, error getting the mode label: {e}");
+            StateModelError::RuntimeError(msg)
+        })?;
     match label_opt {
         None => Err(StateModelError::RuntimeError(format!(
             "Internal Error: get_leg_mode called on leg idx {leg_idx} but mode label is not set"
@@ -212,7 +223,13 @@ pub fn get_mode_label_sequence(
     let mut labels: Vec<i64> = vec![];
 
     for leg_idx in 0..max_trip_legs.get() {
-        let mode_label_opt = get_leg_mode_label(state, leg_idx, state_model, max_trip_legs)?;
+        let mode_label_opt = get_leg_mode_label(state, leg_idx, state_model, max_trip_legs)
+            .map_err(|e| {
+                let msg = format!(
+                    "while getting model label sequence, failed to get mode label for index: {e}"
+                );
+                StateModelError::RuntimeError(msg)
+            })?;
         match mode_label_opt {
             None => break,
             Some(mode_label) => {
@@ -234,12 +251,14 @@ pub fn get_mode_sequence(
 ) -> Result<Vec<String>, StateModelError> {
     let mut modes: Vec<String> = vec![];
     let mut leg_idx = 0;
-    while contains_leg(state, leg_idx, state_model)? {
+
+    while contains_leg(state, leg_idx, state_model, max_trip_legs)? {
         let mode =
             get_existing_leg_mode(state, leg_idx, state_model, max_trip_legs, mode_to_state)?;
         modes.push(mode.to_string());
         leg_idx += 1;
     }
+
     Ok(modes)
 }
 
@@ -256,7 +275,10 @@ pub fn increment_active_leg_idx(
     let next_leg_idx_u64 = match get_active_leg_idx(state, state_model)? {
         Some(leg_idx) => {
             let next = leg_idx + 1;
-            validate_leg_idx(next, max_trip_legs)?;
+            validate_leg_idx(next, max_trip_legs).map_err(|e| {
+                let msg = format!("while incrementing active leg idx, next index is invalid: {e}");
+                StateModelError::RuntimeError(msg)
+            })?;
             next
         }
         None => 0,

--- a/rust/bambam-gtfs-flex/Cargo.toml
+++ b/rust/bambam-gtfs-flex/Cargo.toml
@@ -12,6 +12,7 @@ bambam-core = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 csv = { workspace = true }
+env_logger = { workspace = true }
 flate2 = { workspace = true }
 geo = { workspace = true }
 geo-types = { workspace = true }

--- a/rust/bambam-gtfs-flex/src/app/gtfs_flex_cli.rs
+++ b/rust/bambam-gtfs-flex/src/app/gtfs_flex_cli.rs
@@ -36,6 +36,7 @@ pub struct GtfsFLexCliArguments {
 impl Cli {
     /// runs the app
     pub fn run(&self) -> Result<(), GtfsFlexError> {
+        env_logger::init();
         match &self.command {
             Commands::ProcessGtfsFlexFeeds(args) => {
                 let in_dir = Path::new(&args.input_directory);

--- a/rust/bambam-gtfs-flex/src/app/import_dataset.rs
+++ b/rust/bambam-gtfs-flex/src/app/import_dataset.rs
@@ -106,7 +106,7 @@ pub fn process_gtfs_flex_bundle(
     out_directory_path: &Path,
     date_requested: &str,
 ) -> Result<(), GtfsFlexError> {
-    println!("=== Processing GTFS-Flex bundle ===");
+    log::info!("=== Processing GTFS-Flex bundle ===");
 
     // discover gtfs-flex feeds
     discover_gtfs_flex_feeds(flex_directory_path)?;
@@ -116,7 +116,7 @@ pub fn process_gtfs_flex_bundle(
 
     gtfs_flex_dataset.write(out_directory_path)?;
 
-    println!("=== GTFS-Flex processing complete ===");
+    log::info!("=== GTFS-Flex processing complete ===");
     Ok(())
 }
 
@@ -132,7 +132,7 @@ pub fn discover_gtfs_flex_feeds(flex_directory_path: &Path) -> Result<(), GtfsFl
         error,
     })?;
 
-    println!("Found zip files in {:?}:", flex_directory_path);
+    log::info!("Found zip files in {:?}:", flex_directory_path);
 
     let mut count = 0;
     for entry in entries {
@@ -144,13 +144,13 @@ pub fn discover_gtfs_flex_feeds(flex_directory_path: &Path) -> Result<(), GtfsFl
 
         if path.is_file() && path.extension().is_some_and(|e| e == "zip") {
             if let Some(name) = path.file_name() {
-                println!("      {}", name.to_string_lossy());
+                log::info!("      {}", name.to_string_lossy());
                 count += 1;
             }
         }
     }
 
-    println!("Total GTFS-flex feeds found: {}", count);
+    log::info!("Total GTFS-flex feeds found: {}", count);
 
     Ok(())
 }
@@ -161,7 +161,7 @@ pub fn process_flex_files(
     flex_directory_path: &Path,
     date_requested: &str,
 ) -> Result<GtfsFlexDataset, GtfsFlexError> {
-    println!("Processing GTFS-Flex feeds in {:?}", flex_directory_path);
+    log::info!("Processing GTFS-Flex feeds in {:?}", flex_directory_path);
 
     let iter = std::fs::read_dir(flex_directory_path).map_err(|error| GtfsFlexError::Io {
         path: flex_directory_path.to_path_buf(),
@@ -178,14 +178,14 @@ pub fn process_flex_files(
         let path = entry.path();
 
         if path.is_file() && path.extension().is_some_and(|e| e == "zip") {
-            println!("  Processing {:?}", path);
-
             // extract feed name
             let feed_name = path
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("unknown_feed")
                 .to_string();
+
+            log::info!("Processing feed {feed_name} in file {:?}", path);
 
             // load GTFS
             let gtfs = Gtfs::from_path(&path).map_err(|error| GtfsFlexError::GtfsRead {
@@ -195,11 +195,15 @@ pub fn process_flex_files(
 
             // process files for requested date and time and get valid zones
             let archive_dataset = process_archive(&gtfs, date_requested, &feed_name, idx)?;
+            log::info!(
+                "BAMBAM dataset created with {} records",
+                archive_dataset.records.len()
+            );
             dataset.extend(archive_dataset);
         }
     }
 
-    println!("GTFS-Flex feeds processed!");
+    log::info!("GTFS-Flex feeds processed!");
 
     Ok(dataset)
 }
@@ -217,7 +221,7 @@ pub fn process_archive(
         GtfsFlexError::Runtime(msg)
     })?;
 
-    println!("          requested date: {:?}", date);
+    log::info!("requested date: {:?}", date);
 
     // filter calendar for the requested date
     let weekday = match date.weekday() {
@@ -229,7 +233,7 @@ pub fn process_archive(
         chrono::Weekday::Sat => |c: &Calendar| c.saturday,
         chrono::Weekday::Sun => |c: &Calendar| c.sunday,
     };
-    println!("          requested day: {:?}", date.weekday());
+    log::info!("requested day: {:?}", date.weekday());
 
     let active_service_ids: Vec<&str> = gtfs
         .calendar
@@ -238,7 +242,10 @@ pub fn process_archive(
         .map(|c| c.id.as_str())
         .collect();
 
-    // println!("          active service_ids: {:?}", active_service_ids);
+    log::info!(
+        "ServiceIds active on date {date_requested}: [{}]",
+        active_service_ids.join(", ")
+    );
 
     // 1. Map route_id -> agency_id (fallback to archive_idx if missing)
     // at the end, route_to_agency contains ALL AgencyIds referenced by
@@ -327,9 +334,12 @@ pub fn process_archive(
                     geometry: wkt_str,
                 });
             }
+            [_src, _dst] => {
+                log::debug!("GTFS-Flex Trip {} has 2 StopTime entries but not valid_flex_trip_stops, skipping.", trip.id)
+            }
             other => {
                 log::warn!(
-                    "GTFS-Flex Trip {} has {} StopTime entries, assumed should always be 2",
+                    "GTFS-Flex Trip {} has {} StopTime entries, assumed should always be 2.",
                     trip.id,
                     other.len()
                 );

--- a/rust/bambam-gtfs-flex/src/model/constraint/model.rs
+++ b/rust/bambam-gtfs-flex/src/model/constraint/model.rs
@@ -48,7 +48,7 @@ impl ConstraintModel for GtfsFlexDepartureConstraintModel {
         let current_time = current_datetime(self.params.start_time, state, state_model)?;
         let lookup_result = current_zone(&self.lookup, ctx.dst)?;
         let is_valid = match &lookup_result {
-            Some(src_zone_id) => is_valid_departure(&self.lookup, &src_zone_id, &current_time),
+            Some(src_zone_id) => is_valid_departure(&self.lookup, src_zone_id, &current_time),
             None => Ok(false),
         }?;
         log::debug!(

--- a/rust/bambam-gtfs-flex/src/model/constraint/model.rs
+++ b/rust/bambam-gtfs-flex/src/model/constraint/model.rs
@@ -47,12 +47,13 @@ impl ConstraintModel for GtfsFlexDepartureConstraintModel {
         // there is no supporting relation in the ZoneGraph, otherwise, accept as we will board here.
         let current_time = current_datetime(self.params.start_time, state, state_model)?;
         let lookup_result = current_zone(&self.lookup, ctx.dst)?;
-        let is_valid = match lookup_result {
+        let is_valid = match &lookup_result {
             Some(src_zone_id) => is_valid_departure(&self.lookup, &src_zone_id, &current_time),
             None => Ok(false),
         }?;
         log::debug!(
-            "gtfs-flex frontier is valid (can board here)? {is_valid}, {}",
+            "gtfs-flex frontier is valid (can board here)? {is_valid}, with current_time={}, current_zone={lookup_result:?}, context:\n {}",
+            current_time.format("%Y-%m-%d %H:%M:%S"),
             log_context(ctx, state, state_model)
         );
         Ok(is_valid)

--- a/rust/bambam-gtfs-flex/src/util/zone/relation.rs
+++ b/rust/bambam-gtfs-flex/src/util/zone/relation.rs
@@ -113,7 +113,7 @@ impl TryFrom<&ZonalRelationRecord> for ZonalRelation {
             }),
             _ => {
                 let msg = format!(
-                    "GTFS-Flex record for {}-{} has invalid combination of optional fields",
+                    "GTFS-Flex record for pair {} -> {} has invalid combination of optional fields. all 3 may be omitted, dst_zone_id may be by itself, or all 3 must be present. found dst_zone_id: {dst_zone_id:?} start_time: {start_time:?} end_time: {end_time:?}",
                     record.src_zone_id,
                     record.dst_zone_id.clone().unwrap_or_default()
                 );

--- a/rust/bambam-omf/src/collection/error.rs
+++ b/rust/bambam-omf/src/collection/error.rs
@@ -30,8 +30,8 @@ pub enum OvertureMapsCollectionError {
     PredicateColumnNotFoundError(String),
     #[error("Error creating a runtime to handle async code: {0}")]
     TokioError(String),
-    #[error("Group Mapping operation Failed: {0}")]
-    GroupMappingError(String),
+    #[error("Group Mapping operation Failed, key '{0}' not found in mapping, found {1:?}")]
+    GroupMappingError(String, Vec<String>),
     #[error("Processing records into opportunities failed: {0}")]
     ProcessingError(String),
     #[error("Serializing record into compass format failed: {0}")]

--- a/rust/bambam-omf/src/collection/taxonomy/taxonomy_builder.rs
+++ b/rust/bambam-omf/src/collection/taxonomy/taxonomy_builder.rs
@@ -58,7 +58,7 @@ impl TaxonomyModelBuilder {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 struct TaxonomyCSVRecord {
     #[serde(rename = "Category code")]
     category: String,

--- a/rust/bambam-omf/src/collection/taxonomy/taxonomy_model.rs
+++ b/rust/bambam-omf/src/collection/taxonomy/taxonomy_model.rs
@@ -113,9 +113,10 @@ impl TaxonomyModel {
                         Ok::<bool, OvertureMapsCollectionError>(
                             self.group_mappings
                                 .get(group)
-                                .ok_or(OvertureMapsCollectionError::GroupMappingError(format!(
-                                    "Group {group} was not found in mapping"
-                                )))?
+                                .ok_or(OvertureMapsCollectionError::GroupMappingError(
+                                    group.clone(),
+                                    self.group_mappings.keys().cloned().collect(),
+                                ))?
                                 .contains(category),
                         )
                     })

--- a/rust/bambam/src/model/output_plugin/isochrone/isochrone_output_plugin.rs
+++ b/rust/bambam/src/model/output_plugin/isochrone/isochrone_output_plugin.rs
@@ -114,7 +114,7 @@ impl<'a> TryFrom<&'a BambamOutputRow<'a>> for GetIsochroneRequest {
     fn try_from(value: &'a BambamOutputRow<'a>) -> Result<Self, Self::Error> {
         let info = value.info_ref()?;
         let format = info.get_opportunity_format()?;
-        let filter = info.get_destination_filter()?.map(DestinationFilter);
+        let filter = value.get_destination_filter()?;
         let geometry_model_config = info
             .get_geometry_model()?
             .ok_or_else(|| missing_expected("info.geometry_model"))?;

--- a/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
@@ -63,10 +63,7 @@ impl OutputPlugin for OpportunityOutputPlugin {
         row.set_opportunity_totals(&self.totals)?;
 
         // read destination filter from the row info
-        let filter = row
-            .info_ref()?
-            .get_destination_filter()?
-            .map(DestinationFilter);
+        let filter = row.get_destination_filter()?;
 
         match format {
             OpportunityFormat::Aggregate => {

--- a/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
@@ -142,7 +142,7 @@ fn no_aggregate_opportunities(
     activity_types: &[String],
     opportunity_totals: &HashMap<String, f64>,
 ) -> Result<(), OutputPluginError> {
-    row.set_opportunity_totals(&opportunity_totals)?;
+    row.set_opportunity_totals(opportunity_totals)?;
 
     let bin_config = row.info_ref()?.get_bin_range()?.ok_or_else(|| {
         OutputPluginError::OutputPluginFailed(

--- a/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/opportunity_output_plugin.rs
@@ -45,7 +45,11 @@ impl OutputPlugin for OpportunityOutputPlugin {
                 match format {
                     OpportunityFormat::Aggregate => {
                         // no matches found. inject zeroed-out opportunity data into the row.
-                        no_aggregate_opportunities(&mut row, &self.model.activity_types())?;
+                        no_aggregate_opportunities(
+                            &mut row,
+                            &self.model.activity_types(),
+                            &self.totals,
+                        )?;
                         return Ok(());
                     }
                     OpportunityFormat::Disaggregate => {
@@ -136,7 +140,10 @@ fn process_disaggregate_opportunities(
 fn no_aggregate_opportunities(
     row: &mut BambamOutputRow<'_>,
     activity_types: &[String],
+    opportunity_totals: &HashMap<String, f64>,
 ) -> Result<(), OutputPluginError> {
+    row.set_opportunity_totals(&opportunity_totals)?;
+
     let bin_config = row.info_ref()?.get_bin_range()?.ok_or_else(|| {
         OutputPluginError::OutputPluginFailed(
             "row with aggregate opportunities has no bin range config".to_string(),

--- a/rust/bambam/src/model/output_plugin/opportunity/opportunity_source.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/opportunity_source.rs
@@ -1,4 +1,6 @@
-use crate::model::output_plugin::opportunity::OpportunityDataset;
+use crate::model::output_plugin::opportunity::{
+    source::OverturePlacesMappingConfig, OpportunityDataset,
+};
 
 use super::{
     source::lodes::lodes_ops,
@@ -39,7 +41,7 @@ pub enum OpportunitySource {
     OvertureMapsPlaces {
         collector_config: OvertureMapsCollectorConfig,
         bbox_boundary: Bbox,
-        places_activity_mapping: HashMap<String, Vec<String>>,
+        places_activity_mapping: OverturePlacesMappingConfig,
         buildings_activity_mapping: Option<HashMap<String, Vec<String>>>,
         #[serde(default)]
         release_version: ReleaseVersion,
@@ -70,6 +72,8 @@ impl OpportunitySource {
                 buildings_activity_mapping,
                 release_version,
             } => {
+                let places_mapping = places_activity_mapping.build()?;
+
                 // Instantiate Collection Model Object which re-structures activity mapping
                 // information into a fully functional collection pipeline. This step allows
                 // to reduce repetition in the configuration file by making some assumptions
@@ -78,7 +82,7 @@ impl OpportunitySource {
                     *collector_config,
                     release_version.clone(),
                     *bbox_boundary,
-                    places_activity_mapping.clone(),
+                    places_mapping,
                     buildings_activity_mapping.clone(),
                 )
                 .map_err(|e| format!("Error creating Overture OpportunityCollectionModel: {e}"))?;

--- a/rust/bambam/src/model/output_plugin/opportunity/source/mod.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/mod.rs
@@ -1,2 +1,5 @@
 pub mod lodes;
 pub mod overture_opportunity_collection_model;
+mod overture_places_mapping;
+
+pub use overture_places_mapping::OverturePlacesMappingConfig;

--- a/rust/bambam/src/model/output_plugin/opportunity/source/overture_opportunity_collection_model.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/overture_opportunity_collection_model.rs
@@ -268,12 +268,14 @@ impl OvertureOpportunityCollectionModel {
             activity_types,
         )?;
 
-        log::info!(
-            "Total opportunities per category {:?}",
-            (0..mep_vectors[0].len())
-                .map(|i| mep_vectors.iter().map(|row| row[i] as i16 as f64).sum())
-                .collect::<Vec<f64>>()
-        );
+        if !mep_vectors.is_empty() {
+            log::info!(
+                "Total opportunities per category {:?}",
+                (0..mep_vectors[0].len())
+                    .map(|i| mep_vectors.iter().map(|row| row[i] as i16 as f64).sum())
+                    .collect::<Vec<f64>>()
+            );
+        }
 
         // Collect geometries
         let mep_geometries: Vec<Option<Geometry<f32>>> = buildings_records

--- a/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
@@ -61,7 +61,12 @@ impl OverturePlacesMappingConfig {
                         mep_category_column,
                         mep_category_separator,
                     )?;
-                    let _ = result.insert(omf_label, mep_labels);
+                    for mep_label in mep_labels.into_iter() {
+                        result
+                            .entry(mep_label.clone())
+                            .and_modify(|omf: &mut Vec<String>| omf.push(omf_label.clone()))
+                            .or_insert(vec![omf_label.clone()]);
+                    }
                 }
                 Ok(result)
             }

--- a/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
@@ -6,6 +6,12 @@ use serde::{Deserialize, Serialize};
 
 pub type PlacesMapping = HashMap<String, Vec<String>>;
 
+/// sources a mapping from OvertureMaps Places categories into MEP categories.
+///
+/// # Serde
+///
+/// untagged deserialization. attempts to first deserialize directly as a HashMap.
+/// if that fails, attempts to read as a FromCsv object.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum OverturePlacesMappingConfig {

--- a/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
+++ b/rust/bambam/src/model/output_plugin/opportunity/source/overture_places_mapping.rs
@@ -1,0 +1,94 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use csv::StringRecord;
+use routee_compass_core::util::fs::read_utils;
+use serde::{Deserialize, Serialize};
+
+pub type PlacesMapping = HashMap<String, Vec<String>>;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum OverturePlacesMappingConfig {
+    FromConfig(PlacesMapping),
+    FromCsv {
+        places_mapping_input_file: String,
+        places_category_column: String,
+        mep_category_column: String,
+        mep_category_separator: String,
+    },
+}
+
+impl OverturePlacesMappingConfig {
+    pub fn build(&self) -> Result<PlacesMapping, String> {
+        match self {
+            OverturePlacesMappingConfig::FromConfig(hash_map) => Ok(hash_map.clone()),
+            OverturePlacesMappingConfig::FromCsv {
+                places_mapping_input_file,
+                places_category_column,
+                mep_category_column,
+                mep_category_separator,
+            } => {
+                let mut reader = csv::ReaderBuilder::new()
+                    .has_headers(true)
+                    .from_path(places_mapping_input_file)
+                    .map_err(|e| {
+                        format!(
+                            "failure reading mep mapping csv at {places_mapping_input_file}: {e}"
+                        )
+                    })?;
+                let header_records = reader
+                    .headers()
+                    .map_err(|e| format!("mep mapping csv should have headers. {e}"))?;
+                let header: HashMap<String, usize> = header_records
+                    .iter()
+                    .enumerate()
+                    .map(|(col_idx, name)| (name.to_string(), col_idx))
+                    .collect();
+
+                let mut result = HashMap::new();
+                for (row_idx, row_result) in reader.into_records().enumerate() {
+                    let (omf_label, mep_labels) = process_row(
+                        row_idx,
+                        row_result,
+                        &header,
+                        places_category_column,
+                        mep_category_column,
+                        mep_category_separator,
+                    )?;
+                    let _ = result.insert(omf_label, mep_labels);
+                }
+                Ok(result)
+            }
+        }
+    }
+}
+
+/// helper function to process a row of the MEP mapping CSV file.
+fn process_row(
+    row_idx: usize,
+    row_result: Result<StringRecord, csv::Error>,
+    header: &HashMap<String, usize>,
+    places_category_column: &str,
+    mep_category_column: &str,
+    mep_category_separator: &str,
+) -> Result<(String, Vec<String>), String> {
+    let row = row_result
+        .map_err(|e| format!("failure getting row {row_idx} from mep mapping csv: {e}"))?;
+    let omf_label_col_idx = header.get(places_category_column).ok_or_else(|| {
+        format!("mep mapping csv missing expected {places_category_column} column")
+    })?;
+    let mep_label_col_idx = header
+        .get(mep_category_column)
+        .ok_or_else(|| format!("mep mapping csv missing expected {mep_category_column} column"))?;
+
+    let omf_label = row.get(*omf_label_col_idx)
+        .ok_or_else(|| format!("mep mapping csv row {row_idx} missing expected {places_category_column} column index {omf_label_col_idx}"))?
+        .to_string();
+    let mep_labels: Vec<String> = row.get(*mep_label_col_idx)
+        .ok_or_else(|| format!("mep mapping csv row {row_idx} missing expected {mep_category_column} column index {mep_label_col_idx}"))?
+        .split(mep_category_separator)
+        .map(String::from)
+        .collect();
+
+    Ok((omf_label, mep_labels))
+}

--- a/rust/bambam/src/model/traversal/multimodal/multimodal_traversal_ops.rs
+++ b/rust/bambam/src/model/traversal/multimodal/multimodal_traversal_ops.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroU64;
-use std::sync::OnceLock;
 
 use bambam_core::model::bambam_state;
 use bambam_core::model::state::{
@@ -42,7 +41,12 @@ pub fn mode_switch(
         _ => {
             // no leg assigned or a change in mode -> add the new leg
             let next_leg_idx =
-                state_ops::increment_active_leg_idx(state, state_model, max_trip_legs)?;
+                state_ops::increment_active_leg_idx(state, state_model, max_trip_legs).map_err(
+                    |e| {
+                        let msg = format!("while performing a mode switch, {e}");
+                        StateModelError::RuntimeError(msg)
+                    },
+                )?;
             state_ops::set_leg_mode(state, next_leg_idx, prev_mode, state_model, mode_to_state)?;
         }
     };
@@ -80,12 +84,6 @@ pub fn update_accumulators(
     Ok(())
 }
 
-/// this hack is used because StateModel::contains_key expects a &String, which would require
-/// a new string allocation each time it is invoked here. to avoid this, we store a static [OnceLock]'d
-/// String and reference it in the call once initialized. this should be removed once things are updated
-/// on routee-compass-core, see <https://github.com/NatLabRockies/routee-compass/pull/493>.
-static ROUTE_ID_STRING: OnceLock<String> = OnceLock::new();
-
 /// tests if route_id is set, and if so, copies it to the current trip leg.
 pub fn update_route_id(
     state: &mut [StateVariable],
@@ -94,8 +92,7 @@ pub fn update_route_id(
     leg_idx: LegIdx,
     max_trip_legs: NonZeroU64,
 ) -> Result<(), StateModelError> {
-    let route_id_key = ROUTE_ID_STRING.get_or_init(|| bambam_state::ROUTE_ID.to_string());
-    if state_model.contains_key(route_id_key) {
+    if state_model.contains_key(bambam_state::ROUTE_ID) {
         let route_id_label = state_model.get_custom_i64(state, bambam_state::ROUTE_ID)?;
         state_ops::set_leg_route_id_raw(state, leg_idx, route_id_label, state_model)
     } else {


### PR DESCRIPTION
this PR contains the final set of fixes applied while working toward a successful run of BAMBAM for GTFS-Flex access modeling, which includes the change set from #158 which was cancelled after discovering it was missing a required fix present in this PR.

### GTFS-Flex run fixes

  - make `negate` key on destination filter _optional_ for simplicity
  - DestinationFilter comes from both config and query for mode-specific filtering
  - fix bounds checking errors in multimodal_state_ops
  - improved logging + error reporting during OMF import
  - remove now-unnecessary allocation when calling `state_model.contains_key` and provide error context in multimodal_traversal_ops

### simplify OMF Places mapping

these mappings can be quite long - there are over 2000 OvertureMaps categories total - and so expressing that directly within a bambam config file is noisy. this PR allows the user to alternatively define a CSV source for category mapping:

```toml
[plugin.output_plugins.model.models.opportunity_source.places_activity_mapping]
places_mapping_input_file = "mapping.csv"
places_category_column = "omf_label"
mep_category_column = "mep_labels"
mep_category_separator = "-"  # sep to use when more than one MEP label is produced
```

##### testing

1. unpack and copy these files into the base of the bambam repo:

[omf-csv-test-assets.zip](https://github.com/user-attachments/files/29817765/omf-csv-test-assets.zip)

```
overture-to-mep.csv
test_denver_omf.toml
```

2. run bambam:
```sh
% cargo build -r --manifest-path rust/Cargo.toml
% RUST_LOG=info ./rust/target/release/bambam -c test_denver_omf.toml -q query/denver_extent.json
```

3. a JSON and CSV output should appear with no errors logged to console or into the file contents, and the opportunities counted for each grid cell/mode/timebin come from OvertureMaps categories mapped to MEP categories as defined in teh overture-to-mep.csv file instance.